### PR TITLE
Four Smaller Improvements

### DIFF
--- a/assets/src/content-converter/index.js
+++ b/assets/src/content-converter/index.js
@@ -49,8 +49,8 @@ class ContentConverter extends Component {
 	/*
 	 * handlePostIdsInputChange().
 	 */
-	handlePostIdsInputChange = ( { currentTarget: input } ) => {
-		const postIdsCsv = input.value;
+	handleOnChangeIds = event => {
+		const postIdsCsv = event.target.value;
 
 		this.setState( { postIdsCsv } );
 	};
@@ -67,12 +67,11 @@ class ContentConverter extends Component {
 			<div id="ncc-content">
 				<h1>{ __( 'Newspack Content Converter' ) }</h1>
 				<label htmlFor="ncc_post_ids_csv">{ __( 'Post IDs CSV' ) }</label>
-				<input
-					type="text"
+				<textarea
 					id="ncc_post_ids_csv"
 					placeholder={ __( 'Post IDs CSV' ) }
 					value={ postIdsCsv }
-					onChange={ this.handlePostIdsInputChange }
+					onChange={ this.handleOnChangeIds }
 				/>
 				<input
 					type="submit"

--- a/assets/src/content-converter/style.css
+++ b/assets/src/content-converter/style.css
@@ -7,9 +7,8 @@
 	border-radius: 5px;
 	padding: 20px;
 }
-#ncc-content input[type='text'] {
+#ncc-content textarea {
 	width: 100%;
-	padding: 12px 20px;
 	margin: 8px 0;
 	display: inline-block;
 	border: 1px solid #ccc;
@@ -17,6 +16,8 @@
 	box-sizing: border-box;
 	font-size: 16px;
 	line-height: 24px;
+	font-size: 12px;
+	height: 10em;
 }
 
 #ncc-content input[type='submit'] {


### PR DESCRIPTION
- Fixed auto encoding/decoding POST data

Once we switched `apiFetch` usage by providing the object `data`, instead of the `body` string post content, encoding is done automatically. This was updated now.

- Substituted input element with text area

Changed the `<input>` to a `<textarea>` in the Plugin's GUI, for easier editing of large numbers of CSVs.

- Disabled auto-save on Plugin's page

With the auto-save active by default until now, the Block Editor was auto-saving new drafts every now and then, while the plugin was converting posts (manipulating the Block Editor's contents) and saving the results.

At those times when the Editor would auto-save, it would also rewrite the active URL from the Converter Plugin's current URL:
    `/wp-admin/post-new.php?newspack-content-converter`
to the new draft's edit url:
    `/wp-admin/post.php?post=[NEW_DRAFT_ID]&action=edit`

To clear up a bit more -- it is not that _the converted posts were being auto-saved_, but rather some totally new drafts were being created. Why? Because the Plugin does not work by "Opening/Editing" each Post it wants to convert in the Editor, since that would take a lot of time; instead the Plugin keeps just one instance of the Editor open (also notice the `post-new.php` in the Plugin's URL), and manipulates that single Editor instance (loads contens, triggers convert, gets results, clears up blocks, etc). That's much faster. But since it's using the `post-new.php` with a blank post to do this work, the Block Editor would periodically create new Drafts.

So, even though it might have looked like _the converted posts were being auto-saved_, that's not what was going on -- instead, completely new Drafts were being auto-saved. If you've been testing this plugin on your local site, you can how find that it has auto-generated some Draft posts with empty titles up to now. 

Disabling the auto-save now works fine, and lets the Plugin keep its URL.

I also tried using [these functions](https://github.com/Automattic/jetpack/blob/master/extensions/blocks/slideshow/edit.js#L240-L248) (thanks for your help, @jeffersonrabb ), but these two events seem to be doing something different - they only enable/disable (lock/unlock) the "Update" button in the Block Editor.

However the constant does the job just fine for now.

- Updated console logging

Just for intense dev testings, gives a progress meter in the console:
`converting [postId], [current]/[total]`