### PR TITLE
Patcher for converting pullquote shortcode to pullquote blocks

### DIFF
--- a/dependency-includer-script.php
+++ b/dependency-includer-script.php
@@ -22,6 +22,7 @@ require_once dirname( __FILE__ ) . '/lib/content-patcher/patchers/class-videopat
 require_once dirname( __FILE__ ) . '/lib/content-patcher/patchers/class-audiopatcher.php';
 require_once dirname( __FILE__ ) . '/lib/content-patcher/patchers/class-captionimgpatcher.php';
 require_once dirname( __FILE__ ) . '/lib/content-patcher/patchers/class-shortcodemodulepatcher.php';
+require_once dirname( __FILE__ ) . '/lib/content-patcher/patchers/class-shortcodepullquotepatcher.php';
 require_once dirname( __FILE__ ) . '/lib/content-patcher/elementManipulators/class-htmlelementmanipulator.php';
 require_once dirname( __FILE__ ) . '/lib/content-patcher/elementManipulators/class-squarebracketselementmanipulator.php';
 require_once dirname( __FILE__ ) . '/lib/content-patcher/elementManipulators/class-wpblockmanipulator.php';

--- a/lib/content-patcher/patchers/class-shortcodepullquotepatcher.php
+++ b/lib/content-patcher/patchers/class-shortcodepullquotepatcher.php
@@ -71,6 +71,20 @@ class ShortcodePullquotePatcher extends PatcherAbstract implements PatcherInterf
 	/**
 	 * Convert a shortcode block with the pullquote shortcode into a pullquote block.
 	 *
+	 * The pullquote's 'author' attribute gets converted to a <cite> element, e.g.
+	 *      <!-- wp:shortcode -->
+	 *          [pullquote author"Arthur Author"]pulled text[\pullquote]
+	 *      <!-- /wp:shortcode -->
+	 * gets converted to
+	 *      <!-- wp:pullquote {"align":"left"} -->
+	 *          <figure>
+	 *              <blockquote>
+	 *                  <p>pulled text</p>
+	 *                  <cite>Arthur Author</cite>
+	 *              </blockquote>
+	 *          </figure>
+	 *      <!-- /wp:pullquote -->
+	 *
 	 * @param string $block Raw block content.
 	 * @return string New block content.
 	 */

--- a/lib/content-patcher/patchers/class-shortcodepullquotepatcher.php
+++ b/lib/content-patcher/patchers/class-shortcodepullquotepatcher.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * Patcher for the [pullquote][/pullquote] elements.
+ *
+ * @package Newspack
+ */
+
+namespace NewspackContentConverter\ContentPatcher\Patchers;
+
+use NewspackContentConverter\ContentPatcher\Patchers\PatcherInterface;
+use NewspackContentConverter\ContentPatcher\Patchers\PatcherAbstract;
+use NewspackContentConverter\ContentPatcher\ElementManipulators\SquareBracketsElementManipulator;
+use NewspackContentConverter\ContentPatcher\ElementManipulators\WpBlockManipulator;
+use NewspackContentConverter\ContentPatcher\ElementManipulators\HtmlElementManipulator;
+
+/**
+ * Patcher class for the [pullquote][/pullquote] elements.
+ *
+ * @package NewspackContentConverter\ContentPatcher\Patchers
+ */
+class ShortcodePullquotePatcher extends PatcherAbstract implements PatcherInterface {
+
+	/**
+	 * SquareBracketsElementManipulator service.
+	 *
+	 * @var SquareBracketsElementManipulator
+	 */
+	private $square_brackets_element_manipulator;
+
+	/**
+	 * WpBlockManipulator service.
+	 *
+	 * @var WpBlockManipulator
+	 */
+	private $wp_block_manipulator;
+
+	/**
+	 * VideoPatcher constructor.
+	 */
+	public function __construct() {
+		$this->square_brackets_element_manipulator = new SquareBracketsElementManipulator();
+		$this->wp_block_manipulator                = new WpBlockManipulator();
+	}
+
+	/**
+	 * See the \NewspackContentConverter\ContentPatcher\Patchers\PatcherInterface::patch_blocks_contents for description.
+	 *
+	 * @param string $source_html   HTML source, original content being converted.
+	 * @param string $source_blocks Block content as result of Gutenberg "conversion to blocks".
+	 *
+	 * @return string|false
+	 */
+	public function patch_blocks_contents( $source_html, $source_blocks ) {
+		$matches_blocks = $this->wp_block_manipulator->match_wp_block( 'wp:shortcode', $source_blocks );
+		if ( ! $matches_blocks ) {
+			return $source_blocks;
+		}
+
+		foreach ( $matches_blocks[0] as $matched_block ) {
+			$block = $matched_block[0];
+			if ( false === strpos( $block, '[/pullquote]' ) ) {
+				continue;
+			}
+
+			$converted_block = $this->convert_shortcode_block_to_pullquote( $block );
+			$source_blocks   = str_replace( $block, $converted_block, $source_blocks );
+		}
+
+		return $source_blocks;
+	}
+
+	/**
+	 * Convert a shortcode block with the pullquote shortcode into a pullquote block.
+	 *
+	 * @param string $block Raw block content.
+	 * @return string New block content.
+	 */
+	protected function convert_shortcode_block_to_pullquote( $block ) {
+		// Remove newlines because they confuse the matchers.
+		$block = str_replace( "\n", '', $block );
+
+		$shortcode_matches = $this->square_brackets_element_manipulator->match_elements_with_closing_tags( 'pullquote', $block );
+		$shortcode         = $shortcode_matches[0][0][0];
+
+		// Get content.
+		$allowed_tags = array(
+			'a' => array(
+				'href' => array(),
+			),
+		);
+		$content      = $this->square_brackets_element_manipulator->get_inner_text( 'pullquote', $shortcode );
+		$content      = trim( wp_kses( $content, $allowed_tags ) );
+
+		// Get citation.
+		$cite   = '';
+		$author = trim( $this->square_brackets_element_manipulator->get_attribute_value( 'author', $shortcode ) );
+		if ( $author ) {
+			$cite = '<cite>' . trim( wp_kses( $author, $allowed_tags ) ) . '</cite>';
+		}
+
+		return "<!-- wp:pullquote {\"align\":\"left\"} -->\n<figure class=\"wp-block-pullquote alignleft\"><blockquote><p>$content</p>$cite</blockquote></figure>\n<!-- /wp:pullquote -->";
+	}
+}

--- a/lib/content-patcher/patchers/class-shortcodepullquotepatcher.php
+++ b/lib/content-patcher/patchers/class-shortcodepullquotepatcher.php
@@ -11,7 +11,6 @@ use NewspackContentConverter\ContentPatcher\Patchers\PatcherInterface;
 use NewspackContentConverter\ContentPatcher\Patchers\PatcherAbstract;
 use NewspackContentConverter\ContentPatcher\ElementManipulators\SquareBracketsElementManipulator;
 use NewspackContentConverter\ContentPatcher\ElementManipulators\WpBlockManipulator;
-use NewspackContentConverter\ContentPatcher\ElementManipulators\HtmlElementManipulator;
 
 /**
  * Patcher class for the [pullquote][/pullquote] elements.

--- a/newspack-content-converter.php
+++ b/newspack-content-converter.php
@@ -38,6 +38,7 @@ new \NewspackContentConverter\Converter(
 					new \NewspackContentConverter\ContentPatcher\Patchers\VideoPatcher(),
 					new \NewspackContentConverter\ContentPatcher\Patchers\AudioPatcher(),
 					new \NewspackContentConverter\ContentPatcher\Patchers\ShortcodeModulePatcher(),
+					new \NewspackContentConverter\ContentPatcher\Patchers\ShortcodePullquotePatcher(),
 				)
 			)
 		)

--- a/tests/fixtures/unit/content-patcher/patchers/class-dataprovidershortcodepullquotepatcher.php
+++ b/tests/fixtures/unit/content-patcher/patchers/class-dataprovidershortcodepullquotepatcher.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * Data Provider for tests.
+ *
+ * @package Newspack
+ */
+
+/**
+ * Class DataProviderShortcodePullquotePatcher
+ *
+ * Data Provider for tests concerning unit/content-patcher/patchers/test-shortcodepullquote-patcher.php
+ */
+class DataProviderShortcodePullquotePatcher {
+
+	/**
+	 * Get an unpatched pullquote shortcode.
+	 *
+	 * @return string Unpatched block content.
+	 */
+	public static function get_unpatched_block() {
+		return <<<CONTENT
+<!-- wp:shortcode -->
+[pullquote author="Mary Filardo, president of the 21st Century School Fund" description="" style="new-pullquote"]“It’s just one more nail in the coffin of small towns that are already struggling. The county hospital closed, and the mom-and-pop shops are gone because Walmart opened. When you lose the schools, you lose the community.” [/pullquote]
+<!-- /wp:shortcode -->
+CONTENT;
+	}
+
+	/**
+	 * Get a patched pullquote shortcode.
+	 *
+	 * @return string Patched block content.
+	 */
+	public static function get_patched_block_expected() {
+		return <<<CONTENT
+<!-- wp:pullquote {"align":"left"} -->
+<figure class="wp-block-pullquote alignleft"><blockquote><p>“It’s just one more nail in the coffin of small towns that are already struggling. The county hospital closed, and the mom-and-pop shops are gone because Walmart opened. When you lose the schools, you lose the community.”</p><cite>Mary Filardo, president of the 21st Century School Fund</cite></blockquote></figure>
+<!-- /wp:pullquote -->
+CONTENT;
+	}
+
+	/**
+	 * Get an unpatched pullquote shortcode with no defined author.
+	 *
+	 * @return string Unpatched block content.
+	 */
+	public static function get_unpatched_block_no_author() {
+		return <<<CONTENT
+<!-- wp:shortcode -->
+[pullquote author="" description="" style="new-pullquote"]The nation’s school districts spend about $46 billion less per year on facility upkeep than is needed to maintain “healthy and safe” learning environments, according to the 21st Century School Fund.[/pullquote]
+<!-- /wp:shortcode -->
+CONTENT;
+	}
+
+	/**
+	 * Get a patched pullquote shortcode with no defined author.
+	 *
+	 * @return string Patched block content.
+	 */
+	public static function get_patched_block_no_author_expected() {
+		return <<<CONTENT
+<!-- wp:pullquote {"align":"left"} -->
+<figure class="wp-block-pullquote alignleft"><blockquote><p>The nation’s school districts spend about $46 billion less per year on facility upkeep than is needed to maintain “healthy and safe” learning environments, according to the 21st Century School Fund.</p></blockquote></figure>
+<!-- /wp:pullquote -->
+CONTENT;
+	}
+
+	/**
+	 * Get an unpatched non-relevant content.
+	 *
+	 * @return string Unpatched block content.
+	 */
+	public static function get_unpatched_blocks_non_pertinent() {
+		return <<<CONTENT
+<!-- wp:paragraph -->
+<p>This is a paragraph.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:shortcode -->
+[nonpertinent shortcode att="test"]This is some content[/nonpertinent]
+<!-- /wp:shortcode -->
+
+<!-- wp:paragraph -->
+<p>This is a paragraph after.</p>
+<!-- /wp:paragraph -->
+CONTENT;
+	}
+
+	/**
+	 * Get patched non-relevant content.
+	 *
+	 * @return string Patched block content.
+	 */
+	public static function get_patched_blocks_non_pertinent_expected() {
+		return <<<CONTENT
+<!-- wp:paragraph -->
+<p>This is a paragraph.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:shortcode -->
+[nonpertinent shortcode att="test"]This is some content[/nonpertinent]
+<!-- /wp:shortcode -->
+
+<!-- wp:paragraph -->
+<p>This is a paragraph after.</p>
+<!-- /wp:paragraph -->
+CONTENT;
+	}
+}

--- a/tests/unit/content-patcher/patchers/test-shortcodepullquote-patcher.php
+++ b/tests/unit/content-patcher/patchers/test-shortcodepullquote-patcher.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Test class for the NewspackContentConverter\ContentPatcher\Patchers\ShortcodePullquotePatcher.
+ *
+ * @package Newspack
+ */
+
+use NewspackContentConverter\ContentPatcher\Patchers\PatcherAbstract;
+use NewspackContentConverter\ContentPatcher\Patchers\ShortcodePullquotePatcher;
+
+/**
+ * Class ShortcodePullquotePatcher
+ */
+class TestPullquoteShortcodePatcher extends WP_UnitTestCase {
+
+	/**
+	 * ShortcodePullquotePatcher.
+	 *
+	 * @var PatcherAbstract
+	 */
+	private $patcher;
+
+	/**
+	 * DataProviderShortcodePullquotePatcher.
+	 *
+	 * @var DataProviderShortcodePullquotePatcher
+	 */
+	private $data_provider;
+
+	/**
+	 * Override setUp.
+	 */
+	public function setUp() {
+		$this->fixtures_dir = dirname( __FILE__ ) . '/../../../fixtures/unit/content-patcher/patchers/';
+
+		require_once $this->fixtures_dir . 'class-dataprovidershortcodepullquotepatcher.php';
+
+		$this->patcher       = new ShortcodePullquotePatcher();
+		$this->data_provider = new DataProviderShortcodePullquotePatcher();
+	}
+
+	/**
+	 * Test a full pullquote shortcode conversion.
+	 */
+	public function test_patch_pullquote_shortcode() {
+		$blocks_before_patching = $this->data_provider->get_unpatched_block();
+		$expected               = $this->data_provider->get_patched_block_expected();
+
+		$actual = $this->patcher->patch_blocks_contents( '', $blocks_before_patching );
+		$this->assertSame( $expected, $actual );
+	}
+
+	/**
+	 * Test a pullquote shortcode conversion where no author is defined.
+	 */
+	public function test_patch_pullquote_shortcode_no_author() {
+		$blocks_before_patching = $this->data_provider->get_unpatched_block_no_author();
+		$expected               = $this->data_provider->get_patched_block_no_author_expected();
+
+		$actual = $this->patcher->patch_blocks_contents( '', $blocks_before_patching );
+		$this->assertSame( $expected, $actual );
+	}
+
+	/**
+	 * Test a pullquote shortcode conversion on data that doesn't need converting.
+	 */
+	public function test_patch_module_non_pertinent() {
+		$blocks_before_patching = $this->data_provider->get_unpatched_blocks_non_pertinent();
+		$expected               = $this->data_provider->get_patched_blocks_non_pertinent_expected();
+
+		$actual = $this->patcher->patch_blocks_contents( '', $blocks_before_patching );
+		$this->assertSame( $expected, $actual );
+	}
+}


### PR DESCRIPTION
This patcher converts the `pullquote` shortcode used by Hechinger (and potentially other sites) into `pullquote` blocks.

Closes https://github.com/Automattic/newspack-issues/issues/40

Here are some examples:

**On Hechinger:**
<img width="511" alt="Screen Shot 2019-11-18 at 11 38 00 AM" src="https://user-images.githubusercontent.com/7317227/69084876-00e98780-09fa-11ea-938a-5f094ab2dab4.png">

**On Newspack:**
<img width="591" alt="Screen Shot 2019-11-18 at 11 38 10 AM" src="https://user-images.githubusercontent.com/7317227/69084879-00e98780-09fa-11ea-9a84-62f509af99fa.png">

**On Hechinger**
<img width="530" alt="Screen Shot 2019-11-18 at 11 38 21 AM" src="https://user-images.githubusercontent.com/7317227/69084880-00e98780-09fa-11ea-8642-d85e0d6e12b3.png">

**On Newspack:**
<img width="556" alt="Screen Shot 2019-11-18 at 11 38 30 AM" src="https://user-images.githubusercontent.com/7317227/69084881-00e98780-09fa-11ea-979d-2fe6ed8a95ac.png">

To test:
- Run unit tests.
- Once content converter is updated to handle WP 5.3, run the content converter to verify for real.
