### PR TITLE
Do not let Converter Plugin process posts with not post_content

### DIFF
--- a/lib/class-installer.php
+++ b/lib/class-installer.php
@@ -170,7 +170,8 @@ class Installer {
 									  SELECT {$wp_posts_columns_csv}
 									  FROM {$wp_posts_table}
 									  WHERE post_status IN ({$statuses_placeholders_csv})
-									  AND post_type IN ({$type_placeholders_csv}) ;";
+									  AND post_type IN ({$type_placeholders_csv}) 
+									  AND post_content <> '' ;";
 		$wpdb->get_results( $wpdb->prepare( $sql_placeholders, array_merge( $post_statuses, $post_types ) ) );
 
 		// Insert specified content into plugin's table.


### PR DESCRIPTION
This PR leaves out from conversion those posts/pages which have empty `post_content`.

These conversion attempts used to work with WP ver previous to 5.3, but because of 5.3's stricter checks they now fail.