### PR TITLE
Safe retry hiding HTML elements and injecting root div

### DIFF
--- a/assets/src/index.js
+++ b/assets/src/index.js
@@ -30,7 +30,7 @@ var nccInsertRootAdjacentToElementByClass = function(className) {
 
 // Wrapper function which enables retrying a callback after a timeout interval and for a defined maxAttempts (useful to retry
 // actions for elements which haven't yet been injected into DOM).
-function nccCallbackWithRetry(callback, callbackParam, maxAttempts = 5, timeout = 1000) {
+function nccCallbackWithRetry(callback, callbackParam, maxAttempts = 10, timeout = 1000) {
 	return new Promise(function(resolve, reject) {
 		var doCallback = function(attempt) {
 			try {

--- a/assets/src/index.js
+++ b/assets/src/index.js
@@ -13,29 +13,37 @@ import Conversion from './conversion';
 import Patchers from './patchers';
 import './style.css';
 
-function nccHideElement(element) {
-	element.style.display = 'none';
+var nccGetElementByClassName = function (className) {
+	var elements = document.getElementsByClassName(className);
+	if ('undefined' == typeof elements || !elements.length)
+		throw 'Not found element by class name ' + className;
+	return elements[0];
 }
 
-function nccInsertRootAdjacentToElement(element) {
-	element.insertAdjacentHTML('afterend', '<div id="root"></div>');
-}
+var nccHideElementByClass = function(className) {
+	nccGetElementByClassName(className).style.display = 'none';
+};
+
+var nccInsertRootAdjacentToElementByClass = function(className) {
+	nccGetElementByClassName(className).insertAdjacentHTML('afterend', '<div id="root"></div>');
+};
 
 // Wrapper function which enables retrying a callback after a timeout interval and for a defined maxAttempts (useful to retry
 // actions for elements which haven't yet been injected into DOM).
-function nccCallbackWithRetry( callback, maxAttempts = 5, timeout = 1000 ) {
+function nccCallbackWithRetry(callback, callbackParam, maxAttempts = 5, timeout = 1000) {
 	return new Promise(function(resolve, reject) {
 		var doCallback = function(attempt) {
 			try {
-				callback();
-				Promise(resolve, reject);
+				callback(callbackParam);
+				resolve();
 			} catch (e) {
 				if (0 == attempt) {
-					reject(e);
+					console.log('Final error: ' + e);
 				} else {
 					setTimeout(function() {
 						doCallback(attempt - 1);
 					}, timeout);
+					console.log(e);
 				}
 			}
 		};
@@ -59,10 +67,10 @@ window.onload = function() {
 		render(<ContentRepatcher />, div_content_repatcher);
 	} else {
 		// Converter app sits on top of the Gutenberg Block Editor.
-		nccCallbackWithRetry( nccHideElement( document.getElementsByClassName( 'edit-post-header' )[ 0 ] ) );
-		nccCallbackWithRetry( nccHideElement( document.getElementsByClassName( 'edit-post-layout__content' )[ 0 ] ) );
-		nccCallbackWithRetry( nccHideElement( document.getElementsByClassName( 'edit-post-sidebar' )[ 0 ] ) );
-		nccCallbackWithRetry( nccInsertRootAdjacentToElement( document.getElementsByClassName( 'edit-post-header' )[ 0 ] ) );
+		nccCallbackWithRetry(nccHideElementByClass, 'edit-post-header');
+		nccCallbackWithRetry(nccHideElementByClass, 'edit-post-layout__content');
+		nccCallbackWithRetry(nccHideElementByClass, 'edit-post-sidebar');
+		nccCallbackWithRetry(nccInsertRootAdjacentToElementByClass, 'edit-post-header');
 
 		window.onbeforeunload = function() {};
 

--- a/newspack-content-converter.php
+++ b/newspack-content-converter.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Newspack Content Converter
  * Description: Mass converts pre-Gutenberg HTML content to Gutenberg Blocks.
- * Version: 0.0.1-alpha
+ * Version: 0.0.5-alpha
  * Author: Automattic
  * Author URI: https://newspack.blog/
  * License: GPL2


### PR DESCRIPTION
This is a response to the externally reported issue #24 

It's probable that some HTML elements are not yet inserted/rendered in the DOM when this script is manipulating them. Here performing the actions on those HTML elements by using a custom function `nccCallbackWithRetry`, which executes a callback several times over (`maxAttempts`) and allows for a time interval in between those calls (`timeout`) to allow even slower browsers to render all the elements into DOM.

To test:
- pull the branch,
- build by running:
`nvm use 10.10.0 && npm ci && npm run clean && npm run build:webpack -- --watch`
- make sure you have at least one published Post or Page,
- Activate the plugin,
- via the WP-admin menu click "Newspack Content Converter" > "Run Conversion", then click the "Start Conversion Now" button,
- simply confirm that the Conversion app loads correctly, and starts running the conversion.