### PR TITLE
Added better error handling in React app

### DIFF
--- a/assets/src/utilities/index.js
+++ b/assets/src/utilities/index.js
@@ -43,7 +43,6 @@ export function runSinglePost(postId) {
 		.catch(function(error) {
 			console.error('An error occured:');
 			console.error(error);
-			console.error('Continuing with next Post ID.');
 		});
 }
 

--- a/assets/src/utilities/index.js
+++ b/assets/src/utilities/index.js
@@ -39,7 +39,12 @@ export function runSinglePost(postId) {
 		.then(html => insertClassicBlockWithContent(html))
 		.then(html => dispatchConvertClassicToBlocks(html))
 		.then(html => getAllBlocksContents(postId, html))
-		.then(([blocks, html]) => updatePost(postId, blocks, html));
+		.then(([blocks, html]) => updatePost(postId, blocks, html))
+		.catch(function(error) {
+			console.error('An error occured:');
+			console.error(error);
+			console.error('Continuing with next Post ID.');
+		});
 }
 
 /**

--- a/assets/src/utilities/index.js
+++ b/assets/src/utilities/index.js
@@ -40,7 +40,7 @@ export function runSinglePost(postId) {
 		.then(html => dispatchConvertClassicToBlocks(html))
 		.then(html => getAllBlocksContents(postId, html))
 		.then(([blocks, html]) => updatePost(postId, blocks, html))
-		.catch(function(error) {
+		.catch(error => {
 			console.error('An error occured:');
 			console.error(error);
 		});

--- a/newspack-content-converter.php
+++ b/newspack-content-converter.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Newspack Content Converter
  * Description: Mass converts pre-Gutenberg HTML content to Gutenberg Blocks.
- * Version: 0.0.5-alpha
+ * Version: 0.0.6-alpha
  * Author: Automattic
  * Author URI: https://newspack.blog/
  * License: GPL2


### PR DESCRIPTION
Fixes #27 

This PR employs a very simple error handling. Until now, if a Post failed to get converted (for example due to unexpected/invalid Post content, or a server becoming nonresponsive and the request a times out), the whole conversion batch would halt, and no other Posts in this batch would get converted either. And now, if an error occurs, the rest of the Posts in the batch will continue to get processed.

Testing instructions:
- pull branch and build with `nvm use 10.10.0 && npm ci && npm run clean && npm run build:webpack -- --watch`
- before Activating the Plugin, first make sure you have two published Posts with some HTML content, not blocks (at least two Posts, but don't use more than 10 in order to have a quick test),
- now Activate the Plugin,
- after Activation, manually edit the `ncc_wp_posts` table, and set the first post to fail during conversion by setting its `ncc_wp_posts`.`post_content` to literally `&nbsp;` (one HTML encoded non breaking space) -- an attempt to convert this Post's content in Gutenberg will throw an error, and we'll make sure that the next Post is still successfully converted,
- go to WP-admin > Newspack Content Converter > Run Conversion, and click the big blue button Run Conversion,
- wait for the conversion to finish (check the Console outputs if you wish),
- go back to the `ncc_wp_posts` and spot the following: all the other entries in this table besides
the first post (the one you edited and set it's content to one space) should have some conversion results in the `post_conten_gutenberg_converted` column. If they do, this means that even though the first broke with error, the other posts were converted successfully.