### PR TITLE
WP-Prettier coding standards applied

### DIFF
--- a/assets/src/content-converter/index.js
+++ b/assets/src/content-converter/index.js
@@ -13,8 +13,8 @@ class ContentConverter extends Component {
 	/**
 	 * Constructor.
 	 */
-	constructor(props) {
-		super(props);
+	constructor( props ) {
+		super( props );
 
 		this.state = {
 			isActive: null,
@@ -26,32 +26,32 @@ class ContentConverter extends Component {
 
 	componentDidMount() {
 		return fetchConversionBatch()
-			.then(response => {
-				if (response && response.ids) {
+			.then( response => {
+				if ( response && response.ids ) {
 					const { ids: postIds, thisBatch, maxBatch } = response;
-					this.setState({ postIds, thisBatch, maxBatch, isActive: true });
-					console.log(' ----------------------- ABOUT TO CONVERT IDS: ' + postIds);
-					return runMultiplePosts(postIds);
+					this.setState( { postIds, thisBatch, maxBatch, isActive: true } );
+					console.log( ' ----------------------- ABOUT TO CONVERT IDS: ' + postIds );
+					return runMultiplePosts( postIds );
 				}
 
-				return new Promise((resolve, reject) => resolve());
-			})
-			.then(() => {
-				return new Promise((resolve, reject) => {
-					console.log(' ----------------------- FINISHED.');
-					if (this.state.postIds) {
-						this.setState({ isActive: null });
+				return new Promise( ( resolve, reject ) => resolve() );
+			} )
+			.then( () => {
+				return new Promise( ( resolve, reject ) => {
+					console.log( ' ----------------------- FINISHED.' );
+					if ( this.state.postIds ) {
+						this.setState( { isActive: null } );
 						// This should disable the browser's "Reload page?" popup, although it doesn't always work as expected.
 						window.onbeforeunload = function() {};
 						// Reload this window to pick up the next batch.
-						window.location.reload(true);
+						window.location.reload( true );
 					} else {
-						this.setState({ isActive: false });
+						this.setState( { isActive: false } );
 					}
 
 					return resolve();
-				});
-			});
+				} );
+			} );
 	}
 
 	/*
@@ -60,41 +60,41 @@ class ContentConverter extends Component {
 	render() {
 		const { isActive, thisBatch, maxBatch } = this.state;
 
-		if (null == isActive) {
+		if ( null == isActive ) {
 			return (
 				<div className="ncc-page">
-					<h1>{__('Content Conversion')}</h1>
+					<h1>{ __( 'Content Conversion' ) }</h1>
 					<img src="/wp-admin/images/wpspin_light.gif" /> Loading...
 				</div>
 			);
-		} else if (true == isActive) {
+		} else if ( true == isActive ) {
 			return (
 				<div className="ncc-page">
-					<h1>{__('Content Conversion...')}</h1>
+					<h1>{ __( 'Content Conversion...' ) }</h1>
 					<img src="/wp-admin/images/wpspin_light.gif" />
-					&nbsp; {__('Now processing batch')} {thisBatch}/{maxBatch} ...
+					&nbsp; { __( 'Now processing batch' ) } { thisBatch }/{ maxBatch } ...
 					<br />
-					<h3>{__('Do not close this page!')}</h3>
+					<h3>{ __( 'Do not close this page!' ) }</h3>
 					<ul>
 						<li>
-							{__(
+							{ __(
 								'This page will occasionally automatically reload, and notify you when the conversion is complete.'
-							)}
+							) }
 						</li>
-						<li>{__('If asked to Reload, chose yes.')}</li>
+						<li>{ __( 'If asked to Reload, chose yes.' ) }</li>
 						<li>
-							{__(
+							{ __(
 								'You may also carefully open an additional tab to convert another batch in parallel.'
-							)}
+							) }
 						</li>
 					</ul>
 				</div>
 			);
-		} else if (false == isActive) {
+		} else if ( false == isActive ) {
 			return (
 				<div className="ncc-page">
-					<h1>{__('Content Conversion Complete')}</h1>
-					<p>{__('All queued content has been converted.')}</p>
+					<h1>{ __( 'Content Conversion Complete' ) }</h1>
+					<p>{ __( 'All queued content has been converted.' ) }</p>
 				</div>
 			);
 		}

--- a/assets/src/content-repatcher/index.js
+++ b/assets/src/content-repatcher/index.js
@@ -29,7 +29,12 @@ class ContentRepatcher extends Component {
 		return fetchPatchingInfo()
 			.then( response => {
 				if ( response ) {
-					const { isPatchingOngoing, queuedBatchesPatching, maxBatchPatching, patchingBatchSize } = response;
+					const {
+						isPatchingOngoing,
+						queuedBatchesPatching,
+						maxBatchPatching,
+						patchingBatchSize,
+					} = response;
 					if ( '0' == isPatchingOngoing ) {
 						this.setState( { isActive: false } );
 						console.log( ' ----------------------- FINISHED.' );
@@ -38,7 +43,13 @@ class ContentRepatcher extends Component {
 						throw new Error( 'Patching is not scheduled.' );
 					}
 
-					this.setState( { isPatchingOngoing, queuedBatchesPatching, maxBatchPatching, patchingBatchSize , isActive: true } );
+					this.setState( {
+						isPatchingOngoing,
+						queuedBatchesPatching,
+						maxBatchPatching,
+						patchingBatchSize,
+						isActive: true,
+					} );
 				}
 
 				console.log( ' ----------------------- ABOUT TO PATCH NEXT BATCH.' );
@@ -49,9 +60,8 @@ class ContentRepatcher extends Component {
 				if ( null == response ) {
 					this.setState( { isActive: false } );
 				} else if ( response && response.result && 'patched' == response.result ) {
-
 					// Reload this window to pick up the next batch.
-					window.location.reload(true);
+					window.location.reload( true );
 				}
 				console.log( ' ----------------------- FINISHED.' );
 
@@ -67,57 +77,68 @@ class ContentRepatcher extends Component {
 	 */
 	render() {
 		const { isActive, queuedBatchesPatching, maxBatchPatching, patchingBatchSize } = this.state;
-		const queuedBatchesPatchingCsv = queuedBatchesPatching ? queuedBatchesPatching.join( ', ' ) : '';
+		const queuedBatchesPatchingCsv = queuedBatchesPatching
+			? queuedBatchesPatching.join( ', ' )
+			: '';
 
 		if ( null == isActive ) {
-
 			return (
 				<div className="ncc-page">
 					<h1>{ __( 'Content Re-patching' ) }</h1>
 					<img src="/wp-admin/images/wpspin_light.gif" /> Loading...
 				</div>
 			);
-
 		} else if ( true == isActive ) {
-
 			return (
 				<div className="ncc-page">
 					<h1>{ __( 'Content Re-patching...' ) }</h1>
 					<img src="/wp-admin/images/wpspin_light.gif" />
 					&nbsp; { __( 'Now patching the next batch' ) } ...
 					<br />
-
 					<h3>{ __( 'Patching is currently in progress...' ) }</h3>
 					<ul>
 						<li>
-							{ __( 'patching batches processed so far:' ) } <b><u>{ queuedBatchesPatchingCsv }</u></b>
+							{ __( 'patching batches processed so far:' ) }{' '}
+							<b>
+								<u>{ queuedBatchesPatchingCsv }</u>
+							</b>
 						</li>
 						<li>
-							{ __( 'total batches queued:' ) } <b><u>{ maxBatchPatching }</u></b>
+							{ __( 'total batches queued:' ) }{' '}
+							<b>
+								<u>{ maxBatchPatching }</u>
+							</b>
 						</li>
 						<li>
-							{ __( 'conversion batch size (posts per batch):' ) } <b><u>{ patchingBatchSize }</u></b>
+							{ __( 'conversion batch size (posts per batch):' ) }{' '}
+							<b>
+								<u>{ patchingBatchSize }</u>
+							</b>
 						</li>
 					</ul>
-
 					<h3>{ __( 'Do not close this page!' ) }</h3>
 					<ul>
-						<li>{ __( 'This page will occasionally automatically reload, and notify you when the patching is complete.') }</li>
+						<li>
+							{ __(
+								'This page will occasionally automatically reload, and notify you when the patching is complete.'
+							) }
+						</li>
 						<li>{ __( 'If asked to Reload, chose yes.' ) }</li>
-						<li>{ __( 'You may also carefully open an additional tab to process another batch in parallel.' ) }</li>
+						<li>
+							{ __(
+								'You may also carefully open an additional tab to process another batch in parallel.'
+							) }
+						</li>
 					</ul>
 				</div>
 			);
-
 		} else if ( false == isActive ) {
-
 			return (
 				<div className="ncc-page">
 					<h1>{ __( 'Content Re-patching Complete' ) }</h1>
-					<p>{ __( 'All queued content has been patched.') }</p>
+					<p>{ __( 'All queued content has been patched.' ) }</p>
 				</div>
 			);
-
 		}
 	}
 }

--- a/assets/src/conversion/index.js
+++ b/assets/src/conversion/index.js
@@ -7,10 +7,9 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies.
  */
-import { fetchConversionInfo, postConversionInitialize } from "../utilities";
+import { fetchConversionInfo, postConversionInitialize } from '../utilities';
 
 class Conversion extends Component {
-
 	constructor( props ) {
 		super( props );
 
@@ -24,36 +23,51 @@ class Conversion extends Component {
 	}
 
 	componentDidMount() {
-		return fetchConversionInfo()
-			.then( response => {
-				if ( response ) {
-					const { isConversionOngoing, queuedEntries, conversionBatchSize, queuedBatches, maxBatch } = response;
-					const queuedBatchesCsv = queuedBatches.join( ',' );
-					this.setState( { isConversionOngoing, queuedEntries, conversionBatchSize, queuedBatchesCsv, maxBatch } );
-				}
-				return new Promise( ( resolve, reject ) => resolve() );
-			} );
+		return fetchConversionInfo().then( response => {
+			if ( response ) {
+				const {
+					isConversionOngoing,
+					queuedEntries,
+					conversionBatchSize,
+					queuedBatches,
+					maxBatch,
+				} = response;
+				const queuedBatchesCsv = queuedBatches.join( ',' );
+				this.setState( {
+					isConversionOngoing,
+					queuedEntries,
+					conversionBatchSize,
+					queuedBatchesCsv,
+					maxBatch,
+				} );
+			}
+			return new Promise( ( resolve, reject ) => resolve() );
+		} );
 	}
 
 	handleOnClickInitializeConversion = () => {
-		return postConversionInitialize()
-			.then( response => {
-				console.log(response)
+		return postConversionInitialize().then( response => {
+			console.log( response );
 
-				if ( ! response || ! response.result || 'queued' != response.result ) {
-					return new Promise( ( resolve, reject ) => resolve() );
-				}
+			if ( ! response || ! response.result || 'queued' != response.result ) {
+				return new Promise( ( resolve, reject ) => resolve() );
+			}
 
-				// Redirect to Converter app to begin conversion.
-				window.parent.location = '/wp-admin/post-new.php?newspack-content-converter';
-			} );
+			// Redirect to Converter app to begin conversion.
+			window.parent.location = '/wp-admin/post-new.php?newspack-content-converter';
+		} );
 	};
 
 	render() {
-		const { isConversionOngoing, queuedEntries, conversionBatchSize, queuedBatchesCsv, maxBatch } = this.state;
+		const {
+			isConversionOngoing,
+			queuedEntries,
+			conversionBatchSize,
+			queuedBatchesCsv,
+			maxBatch,
+		} = this.state;
 
 		if ( '1' == isConversionOngoing ) {
-
 			return (
 				<div className="ncc-page">
 					<h1>{ __( 'Run Conversion' ) }</h1>
@@ -62,23 +76,35 @@ class Conversion extends Component {
 					<h3>{ __( 'Converson is currently in progress...' ) }</h3>
 					<ul>
 						<li>
-							{ __( 'conversion batches processed so far:' ) } <b><u>{ queuedBatchesCsv }</u></b>
+							{ __( 'conversion batches processed so far:' ) }{' '}
+							<b>
+								<u>{ queuedBatchesCsv }</u>
+							</b>
 						</li>
 						<li>
-							{ __( 'total batches queued:' ) } <b><u>{ maxBatch }</u></b>
+							{ __( 'total batches queued:' ) }{' '}
+							<b>
+								<u>{ maxBatch }</u>
+							</b>
 						</li>
 						<li>
-							{ __( 'conversion batch size (posts per batch):' ) } <b><u>{ conversionBatchSize }</u></b>
+							{ __( 'conversion batch size (posts per batch):' ) }{' '}
+							<b>
+								<u>{ conversionBatchSize }</u>
+							</b>
 						</li>
 					</ul>
 					<p>
-						<i>* { __( 'note: keep an eye on your active browser tabs currently performing the conversion' ) }</i>
+						<i>
+							*{' '}
+							{ __(
+								'note: keep an eye on your active browser tabs currently performing the conversion'
+							) }
+						</i>
 					</p>
 				</div>
 			);
-
 		} else {
-
 			return (
 				<div className="ncc-page">
 					<h1>{ __( 'Run Conversion' ) }</h1>
@@ -86,20 +112,25 @@ class Conversion extends Component {
 
 					<h3>{ __( 'Planned conversion' ) }</h3>
 					<ul>
+						<li>{ __( 'the entire queued content will be converted to Gutenberg Blocks' ) }</li>
+						<li>{ __( 'this page will automatically reload for every batch' ) }</li>
 						<li>
-							{ __( 'the entire queued content will be converted to Gutenberg Blocks') }
+							{ __( 'number of posts/entries to be converted:' ) }{' '}
+							<b>
+								<u>{ queuedEntries }</u>
+							</b>
 						</li>
 						<li>
-							{ __( 'this page will automatically reload for every batch') }
+							{ __( 'total conversion batches queued' ) }:{' '}
+							<b>
+								<u>{ maxBatch }</u>
+							</b>
 						</li>
 						<li>
-							{ __( 'number of posts/entries to be converted:') } <b><u>{ queuedEntries }</u></b>
-						</li>
-						<li>
-							{ __( 'total conversion batches queued') }: <b><u>{ maxBatch }</u></b>
-						</li>
-						<li>
-							{ __( 'batch size (posts per batch):' ) } <b><u>{ conversionBatchSize }</u></b>
+							{ __( 'batch size (posts per batch):' ) }{' '}
+							<b>
+								<u>{ conversionBatchSize }</u>
+							</b>
 						</li>
 					</ul>
 					<br />
@@ -112,7 +143,12 @@ class Conversion extends Component {
 						onClick={ event => this.handleOnClickInitializeConversion( event ) }
 					/>
 					<p>
-						<i>* { __( 'note carefully -- once started, the conversion should not be interrupted! Your browser page needs to remain active until conversion is complete. You may, however, manually open multiple browser tabs once the conversion starts, and each of them will fetch and convert another batch of posts in parallel. Running multiple tabs speeds up the conversion. Recommended max number of tabs is 4.' ) }</i>
+						<i>
+							*{' '}
+							{ __(
+								'note carefully -- once started, the conversion should not be interrupted! Your browser page needs to remain active until conversion is complete. You may, however, manually open multiple browser tabs once the conversion starts, and each of them will fetch and convert another batch of posts in parallel. Running multiple tabs speeds up the conversion. Recommended max number of tabs is 4.'
+							) }
+						</i>
 					</p>
 				</div>
 			);

--- a/assets/src/index.js
+++ b/assets/src/index.js
@@ -13,67 +13,67 @@ import Conversion from './conversion';
 import Patchers from './patchers';
 import './style.css';
 
-var nccGetElementByClassName = function (className) {
-	var elements = document.getElementsByClassName(className);
-	if ('undefined' == typeof elements || !elements.length)
+const nccGetElementByClassName = function( className ) {
+	const elements = document.getElementsByClassName( className );
+	if ( 'undefined' == typeof elements || ! elements.length )
 		throw 'Not found element by class name ' + className;
-	return elements[0];
-}
-
-var nccHideElementByClass = function(className) {
-	nccGetElementByClassName(className).style.display = 'none';
+	return elements[ 0 ];
 };
 
-var nccInsertRootAdjacentToElementByClass = function(className) {
-	nccGetElementByClassName(className).insertAdjacentHTML('afterend', '<div id="root"></div>');
+const nccHideElementByClass = function( className ) {
+	nccGetElementByClassName( className ).style.display = 'none';
+};
+
+const nccInsertRootAdjacentToElementByClass = function( className ) {
+	nccGetElementByClassName( className ).insertAdjacentHTML( 'afterend', '<div id="root"></div>' );
 };
 
 // Wrapper function which enables retrying a callback after a timeout interval and for a defined maxAttempts (useful to retry
 // actions for elements which haven't yet been injected into DOM).
-function nccCallbackWithRetry(callback, callbackParam, maxAttempts = 10, timeout = 1000) {
-	return new Promise(function(resolve, reject) {
-		var doCallback = function(attempt) {
+function nccCallbackWithRetry( callback, callbackParam, maxAttempts = 10, timeout = 1000 ) {
+	return new Promise( function( resolve, reject ) {
+		const doCallback = function( attempt ) {
 			try {
-				callback(callbackParam);
+				callback( callbackParam );
 				resolve();
-			} catch (e) {
-				if (0 == attempt) {
-					console.log('Final error: ' + e);
+			} catch ( e ) {
+				if ( 0 == attempt ) {
+					console.log( 'Final error: ' + e );
 				} else {
-					setTimeout(function() {
-						doCallback(attempt - 1);
-					}, timeout);
-					console.log(e);
+					setTimeout( function() {
+						doCallback( attempt - 1 );
+					}, timeout );
+					console.log( e );
 				}
 			}
 		};
-		doCallback(maxAttempts);
-	});
+		doCallback( maxAttempts );
+	} );
 }
 
 window.onload = function() {
-	const div_settings = document.getElementById('ncc-settings');
-	const div_conversion = document.getElementById('ncc-conversion');
-	const div_patchers = document.getElementById('ncc-patchers');
-	const div_content_repatcher = document.getElementById('ncc-content-repatcher');
+	const div_settings = document.getElementById( 'ncc-settings' );
+	const div_conversion = document.getElementById( 'ncc-conversion' );
+	const div_patchers = document.getElementById( 'ncc-patchers' );
+	const div_content_repatcher = document.getElementById( 'ncc-content-repatcher' );
 
-	if (typeof div_settings != 'undefined' && div_settings != null) {
-		render(<Settings />, div_settings);
-	} else if (typeof div_conversion != 'undefined' && div_conversion != null) {
-		render(<Conversion />, div_conversion);
-	} else if (typeof div_patchers != 'undefined' && div_patchers != null) {
-		render(<Patchers />, div_patchers);
-	} else if (typeof div_content_repatcher != 'undefined' && div_content_repatcher != null) {
-		render(<ContentRepatcher />, div_content_repatcher);
+	if ( typeof div_settings != 'undefined' && div_settings != null ) {
+		render( <Settings />, div_settings );
+	} else if ( typeof div_conversion != 'undefined' && div_conversion != null ) {
+		render( <Conversion />, div_conversion );
+	} else if ( typeof div_patchers != 'undefined' && div_patchers != null ) {
+		render( <Patchers />, div_patchers );
+	} else if ( typeof div_content_repatcher != 'undefined' && div_content_repatcher != null ) {
+		render( <ContentRepatcher />, div_content_repatcher );
 	} else {
 		// Converter app sits on top of the Gutenberg Block Editor.
-		nccCallbackWithRetry(nccHideElementByClass, 'edit-post-header');
-		nccCallbackWithRetry(nccHideElementByClass, 'edit-post-layout__content');
-		nccCallbackWithRetry(nccHideElementByClass, 'edit-post-sidebar');
-		nccCallbackWithRetry(nccInsertRootAdjacentToElementByClass, 'edit-post-header');
+		nccCallbackWithRetry( nccHideElementByClass, 'edit-post-header' );
+		nccCallbackWithRetry( nccHideElementByClass, 'edit-post-layout__content' );
+		nccCallbackWithRetry( nccHideElementByClass, 'edit-post-sidebar' );
+		nccCallbackWithRetry( nccInsertRootAdjacentToElementByClass, 'edit-post-header' );
 
 		window.onbeforeunload = function() {};
 
-		render(<ContentConverter />, document.getElementById('root'));
+		render( <ContentConverter />, document.getElementById( 'root' ) );
 	}
 };

--- a/assets/src/patchers/index.js
+++ b/assets/src/patchers/index.js
@@ -7,10 +7,9 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies.
  */
-import { fetchPatchingInfo, postPatchingInitialize } from "../utilities";
+import { fetchPatchingInfo, postPatchingInitialize } from '../utilities';
 
 class Patchers extends Component {
-
 	constructor( props ) {
 		super( props );
 
@@ -24,39 +23,56 @@ class Patchers extends Component {
 	}
 
 	componentDidMount() {
-		return fetchPatchingInfo()
-			.then( response => {
-				if ( response ) {
-					const { isPatchingOngoing, queuedBatchesPatching, maxBatchPatching, patchingBatchSize, queuedEntries } = response;
-					this.setState( { isPatchingOngoing , queuedBatchesPatching, maxBatchPatching, patchingBatchSize, queuedEntries } );
-				}
-				return new Promise( ( resolve, reject ) => resolve() );
-			} );
+		return fetchPatchingInfo().then( response => {
+			if ( response ) {
+				const {
+					isPatchingOngoing,
+					queuedBatchesPatching,
+					maxBatchPatching,
+					patchingBatchSize,
+					queuedEntries,
+				} = response;
+				this.setState( {
+					isPatchingOngoing,
+					queuedBatchesPatching,
+					maxBatchPatching,
+					patchingBatchSize,
+					queuedEntries,
+				} );
+			}
+			return new Promise( ( resolve, reject ) => resolve() );
+		} );
 	}
 
 	handleOnClickInitializePatching = () => {
-		return postPatchingInitialize()
-			.then( response => {
-				console.log(response)
+		return postPatchingInitialize().then( response => {
+			console.log( response );
 
-				if ( ! response || ! response.result || 'queued' != response.result ) {
-					return new Promise( ( resolve, reject ) => resolve() );
-				}
+			if ( ! response || ! response.result || 'queued' != response.result ) {
+				return new Promise( ( resolve, reject ) => resolve() );
+			}
 
-				// Redirect to Converter app to begin conversion.
-				window.parent.location = '/wp-admin/admin.php?page=ncc-content-repatching';
-			} );
+			// Redirect to Converter app to begin conversion.
+			window.parent.location = '/wp-admin/admin.php?page=ncc-content-repatching';
+		} );
 	};
 
 	/*
 	 * render().
 	 */
 	render() {
-		const { isPatchingOngoing, queuedBatchesPatching, maxBatchPatching, patchingBatchSize, queuedEntries } = this.state;
-		const queuedBatchesPatchingCsv = queuedBatchesPatching ? queuedBatchesPatching.join( ', ' ) : '';
+		const {
+			isPatchingOngoing,
+			queuedBatchesPatching,
+			maxBatchPatching,
+			patchingBatchSize,
+			queuedEntries,
+		} = this.state;
+		const queuedBatchesPatchingCsv = queuedBatchesPatching
+			? queuedBatchesPatching.join( ', ' )
+			: '';
 
 		if ( '1' == isPatchingOngoing ) {
-
 			return (
 				<div className="ncc-page">
 					<h1>{ __( 'Re-apply Patchers' ) }</h1>
@@ -65,48 +81,69 @@ class Patchers extends Component {
 					<h3>{ __( 'Patching is currently in progress...' ) }</h3>
 					<ul>
 						<li>
-							{ __( 'patching batches processed so far:' ) } <b><u>{ queuedBatchesPatchingCsv }</u></b>
+							{ __( 'patching batches processed so far:' ) }{' '}
+							<b>
+								<u>{ queuedBatchesPatchingCsv }</u>
+							</b>
 						</li>
 						<li>
-							{ __( 'total batches queued:' ) } <b><u>{ maxBatchPatching }</u></b>
+							{ __( 'total batches queued:' ) }{' '}
+							<b>
+								<u>{ maxBatchPatching }</u>
+							</b>
 						</li>
 						<li>
-							{ __( 'conversion batch size (posts per batch):' ) } <b><u>{ patchingBatchSize }</u></b>
+							{ __( 'conversion batch size (posts per batch):' ) }{' '}
+							<b>
+								<u>{ patchingBatchSize }</u>
+							</b>
 						</li>
 					</ul>
 					<p>
-						<i>* { __( 'note: keep an eye on your active browser tabs currently performing the conversion' ) }</i>
+						<i>
+							*{' '}
+							{ __(
+								'note: keep an eye on your active browser tabs currently performing the conversion'
+							) }
+						</i>
 					</p>
 				</div>
 			);
-
 		} else {
-
 			return (
 				<div className="ncc-page">
 					<h1>{ __( 'Re-apply Patchers' ) }</h1>
 					<br />
 
 					<p>
-						<i>{ __( 'This is a *dev* feature, automatically performed as a part of the conversion.' ) }</i>
+						<i>
+							{ __(
+								'This is a *dev* feature, automatically performed as a part of the conversion.'
+							) }
+						</i>
 					</p>
 
 					<h3>{ __( 'Planned patching' ) }</h3>
 					<ul>
+						<li>{ __( 'patching will be applied on the entire queued content' ) }</li>
+						<li>{ __( 'this page will automatically reload for every batch' ) }</li>
 						<li>
-							{ __( 'patching will be applied on the entire queued content') }
+							{ __( 'number of posts/entries to be patched:' ) }{' '}
+							<b>
+								<u>{ queuedEntries }</u>
+							</b>
 						</li>
 						<li>
-							{ __( 'this page will automatically reload for every batch') }
+							{ __( 'content grouped in total patching batches:' ) }:{' '}
+							<b>
+								<u>{ maxBatchPatching }</u>
+							</b>
 						</li>
 						<li>
-							{ __( 'number of posts/entries to be patched:') } <b><u>{ queuedEntries }</u></b>
-						</li>
-						<li>
-							{ __( 'content grouped in total patching batches:') }: <b><u>{ maxBatchPatching }</u></b>
-						</li>
-						<li>
-							{ __( 'batch size (posts per batch):' ) } <b><u>{ patchingBatchSize }</u></b>
+							{ __( 'batch size (posts per batch):' ) }{' '}
+							<b>
+								<u>{ patchingBatchSize }</u>
+							</b>
 						</li>
 					</ul>
 					<br />
@@ -124,11 +161,15 @@ class Patchers extends Component {
 					/>
 
 					<p>
-						<i>* { __( 'note carefully -- once started, patching should not be interrupted! Your browser page needs to remain active until patching is complete. You may, however, manually open multiple browser tabs once the patching starts, and each of them will fetch and patch another batch of content in parallel. Running multiple tabs speeds up the patching. Recommended max number of tabs is 4.' ) }</i>
+						<i>
+							*{' '}
+							{ __(
+								'note carefully -- once started, patching should not be interrupted! Your browser page needs to remain active until patching is complete. You may, however, manually open multiple browser tabs once the patching starts, and each of them will fetch and patch another batch of content in parallel. Running multiple tabs speeds up the patching. Recommended max number of tabs is 4.'
+							) }
+						</i>
 					</p>
 				</div>
 			);
-
 		}
 	}
 }

--- a/assets/src/settings/index.js
+++ b/assets/src/settings/index.js
@@ -7,7 +7,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies.
  */
-import { fetchSettingsInfo, runMultiplePosts } from "../utilities";
+import { fetchSettingsInfo, runMultiplePosts } from '../utilities';
 
 class Settings extends Component {
 	/**
@@ -26,21 +26,38 @@ class Settings extends Component {
 	}
 
 	componentDidMount() {
-		return fetchSettingsInfo()
-			.then( response => {
-				if ( response ) {
-					const { conversionContentTypesCsv, conversionContentStatusesCsv, conversionBatchSize, patchingBatchSize, queuedEntries } = response;
-					this.setState( { conversionContentTypesCsv, conversionContentStatusesCsv, conversionBatchSize, patchingBatchSize, queuedEntries } );
-				}
-				return new Promise( ( resolve, reject ) => resolve() );
-			} );
+		return fetchSettingsInfo().then( response => {
+			if ( response ) {
+				const {
+					conversionContentTypesCsv,
+					conversionContentStatusesCsv,
+					conversionBatchSize,
+					patchingBatchSize,
+					queuedEntries,
+				} = response;
+				this.setState( {
+					conversionContentTypesCsv,
+					conversionContentStatusesCsv,
+					conversionBatchSize,
+					patchingBatchSize,
+					queuedEntries,
+				} );
+			}
+			return new Promise( ( resolve, reject ) => resolve() );
+		} );
 	}
 
 	/*
 	 * render().
 	 */
 	render() {
-		const { conversionContentTypesCsv, conversionContentStatusesCsv, conversionBatchSize, patchingBatchSize, queuedEntries } = this.state;
+		const {
+			conversionContentTypesCsv,
+			conversionContentStatusesCsv,
+			conversionBatchSize,
+			patchingBatchSize,
+			queuedEntries,
+		} = this.state;
 
 		return (
 			<div className="ncc-page">
@@ -48,25 +65,32 @@ class Settings extends Component {
 				<br />
 
 				<p>
-					{ __( 'Adding content to the queue, enables it to be converted to Gutenberg Blocks. The queue is also a backup point for possible reverting, or re-applying the content patchers (which is one of *dev* functionalities).' ) }
+					{ __(
+						'Adding content to the queue, enables it to be converted to Gutenberg Blocks. The queue is also a backup point for possible reverting, or re-applying the content patchers (which is one of *dev* functionalities).'
+					) }
 				</p>
 				<p>
-					{ __( 'Existing HTML content is first selected by type, and added to a conversion queue. Queued content is then converted.' ) }
+					{ __(
+						'Existing HTML content is first selected by type, and added to a conversion queue. Queued content is then converted.'
+					) }
 				</p>
 				<h3>{ __( 'Specify content type' ) }</h3>
 				<ul>
 					<li>
-						content types: <input type="text" disabled={ true } value={ conversionContentTypesCsv } />
+						content types:{' '}
+						<input type="text" disabled={ true } value={ conversionContentTypesCsv } />
 					</li>
 					<li>
-						content statuses: <input type="text" disabled={ true } value={ conversionContentStatusesCsv } />
+						content statuses:{' '}
+						<input type="text" disabled={ true } value={ conversionContentStatusesCsv } />
 					</li>
 				</ul>
 
 				<h3>{ __( 'Conversion params' ) }</h3>
 				<ul>
 					<li>
-						conversion batch size: <input type="text" disabled={ true } value={ conversionBatchSize } />
+						conversion batch size:{' '}
+						<input type="text" disabled={ true } value={ conversionBatchSize } />
 					</li>
 				</ul>
 
@@ -80,7 +104,10 @@ class Settings extends Component {
 				<h3>{ __( 'Queued stats' ) }</h3>
 				<ul>
 					<li>
-						<b><u>{ queuedEntries }</u></b> posts are currently selected and queued for conversion
+						<b>
+							<u>{ queuedEntries }</u>
+						</b>{' '}
+						posts are currently selected and queued for conversion
 					</li>
 				</ul>
 			</div>

--- a/assets/src/style.css
+++ b/assets/src/style.css
@@ -31,7 +31,7 @@ body {
 	cursor: pointer;
 	border: none;
 	background-color: #2a7de1;
-	box-shadow: 0px 2px 2px rgba(0, 0, 0, 0.25);
+	box-shadow: 0px 2px 2px rgba( 0, 0, 0, 0.25 );
 	color: #fff;
 	text-shadow: none;
 }

--- a/assets/src/utilities/index.js
+++ b/assets/src/utilities/index.js
@@ -13,15 +13,15 @@ const NEWSPACK_CONVERTER_API_BASE_URL = '/newspack-content-converter';
  * @param string postIdsCsv CSV string of Post IDs.
  * @returns {Promise<void>}
  */
-export function runMultiplePosts(postIds) {
-	var result = Promise.resolve();
-	postIds.forEach((postId, key) => {
-		postId = parseInt(postId);
-		result = result.then(() => {
-			console.log(`converting ${postId}, ${key + 1}/${postIds.length} `);
-			return runSinglePost(postId);
-		});
-	});
+export function runMultiplePosts( postIds ) {
+	let result = Promise.resolve();
+	postIds.forEach( ( postId, key ) => {
+		postId = parseInt( postId );
+		result = result.then( () => {
+			console.log( `converting ${ postId }, ${ key + 1 }/${ postIds.length } ` );
+			return runSinglePost( postId );
+		} );
+	} );
 
 	return result;
 }
@@ -33,17 +33,17 @@ export function runMultiplePosts(postIds) {
  * @param postId
  * @returns {Promise<void | never>}
  */
-export function runSinglePost(postId) {
+export function runSinglePost( postId ) {
 	return removeAllBlocks()
-		.then(() => getPostContentById(postId))
-		.then(html => insertClassicBlockWithContent(html))
-		.then(html => dispatchConvertClassicToBlocks(html))
-		.then(html => getAllBlocksContents(postId, html))
-		.then(([blocks, html]) => updatePost(postId, blocks, html))
-		.catch(error => {
-			console.error('An error occured:');
-			console.error(error);
-		});
+		.then( () => getPostContentById( postId ) )
+		.then( html => insertClassicBlockWithContent( html ) )
+		.then( html => dispatchConvertClassicToBlocks( html ) )
+		.then( html => getAllBlocksContents( postId, html ) )
+		.then( ( [ blocks, html ] ) => updatePost( postId, blocks, html ) )
+		.catch( error => {
+			console.error( 'An error occured:' );
+			console.error( error );
+		} );
 }
 
 /**
@@ -51,10 +51,10 @@ export function runSinglePost(postId) {
  * @returns {Promise<any> | Promise}
  */
 export function removeAllBlocks() {
-	return new Promise(function(resolve, reject) {
-		dispatch('core/block-editor').resetBlocks([]);
+	return new Promise( function( resolve, reject ) {
+		dispatch( 'core/block-editor' ).resetBlocks( [] );
 		return resolve();
-	});
+	} );
 }
 
 /**
@@ -63,12 +63,12 @@ export function removeAllBlocks() {
  * @param id
  * @returns string
  */
-export function getPostContentById(id) {
-	return apiFetch({
-		path: NEWSPACK_CONVERTER_API_BASE_URL + `/get-post-content-by-id/${id}`,
-	}).then(response => {
-		return Promise.resolve(response);
-	});
+export function getPostContentById( id ) {
+	return apiFetch( {
+		path: NEWSPACK_CONVERTER_API_BASE_URL + `/get-post-content-by-id/${ id }`,
+	} ).then( response => {
+		return Promise.resolve( response );
+	} );
 }
 
 /**
@@ -77,14 +77,14 @@ export function getPostContentById(id) {
  * @param String html HTML source before conversion.
  * @returns {Promise<any> | Promise}
  */
-export function insertClassicBlockWithContent(html) {
-	return new Promise(function(resolve, reject) {
-		const block = createBlock('core/freeform');
+export function insertClassicBlockWithContent( html ) {
+	return new Promise( function( resolve, reject ) {
+		const block = createBlock( 'core/freeform' );
 		block.attributes.content = html;
-		dispatch('core/block-editor').insertBlocks(block);
+		dispatch( 'core/block-editor' ).insertBlocks( block );
 		// --- OR: let block = wp.blocks.createBlock( "core/freeform", { content: 'test' } );
-		resolve(html);
-	});
+		resolve( html );
+	} );
 }
 
 /**
@@ -93,22 +93,22 @@ export function insertClassicBlockWithContent(html) {
  * @param String html HTML source before conversion.
  * @returns {Promise<any> | Promise}
  */
-export function dispatchConvertClassicToBlocks(html) {
-	return new Promise(function(resolve, reject) {
-		select('core/block-editor')
+export function dispatchConvertClassicToBlocks( html ) {
+	return new Promise( function( resolve, reject ) {
+		select( 'core/block-editor' )
 			.getBlocks()
-			.forEach(function(block, blockIndex) {
-				if (block.name === 'core/freeform') {
-					dispatch('core/editor').replaceBlocks(
+			.forEach( function( block, blockIndex ) {
+				if ( block.name === 'core/freeform' ) {
+					dispatch( 'core/editor' ).replaceBlocks(
 						block.clientId,
-						rawHandler({
-							HTML: getBlockContent(block),
-						})
+						rawHandler( {
+							HTML: getBlockContent( block ),
+						} )
 					);
 				}
-			});
-		resolve(html);
-	});
+			} );
+		resolve( html );
+	} );
 }
 
 /**
@@ -120,11 +120,11 @@ export function dispatchConvertClassicToBlocks(html) {
  * @param String html HTML source before conversion.
  * @returns {Promise<any> | Promise}
  */
-export function getAllBlocksContents(postId, html) {
-	return new Promise(function(resolve, reject) {
-		const allBlocksContents = select('core/editor').getEditedPostContent();
-		resolve([allBlocksContents, html]);
-	});
+export function getAllBlocksContents( postId, html ) {
+	return new Promise( function( resolve, reject ) {
+		const allBlocksContents = select( 'core/editor' ).getEditedPostContent();
+		resolve( [ allBlocksContents, html ] );
+	} );
 }
 
 /**
@@ -135,8 +135,8 @@ export function getAllBlocksContents(postId, html) {
  * @param string html   HTML source before conversion.
  * @returns {*}
  */
-export function updatePost(postId, blocks, html) {
-	return apiFetch({
+export function updatePost( postId, blocks, html ) {
+	return apiFetch( {
 		path: NEWSPACK_CONVERTER_API_BASE_URL + '/conversion/update-post',
 		method: 'POST',
 		data: {
@@ -144,49 +144,49 @@ export function updatePost(postId, blocks, html) {
 			content_blocks: blocks,
 			content_html: html,
 		},
-	}).then(response => Promise.resolve(response));
+	} ).then( response => Promise.resolve( response ) );
 }
 
 export function fetchConversionBatch() {
-	return apiFetch({
+	return apiFetch( {
 		path: NEWSPACK_CONVERTER_API_BASE_URL + '/conversion/get-batch-data',
-	}).then(response => Promise.resolve(response));
+	} ).then( response => Promise.resolve( response ) );
 }
 
 export function fetchSettingsInfo() {
-	return apiFetch({
+	return apiFetch( {
 		path: NEWSPACK_CONVERTER_API_BASE_URL + '/settings/get-info',
-	}).then(response => Promise.resolve(response));
+	} ).then( response => Promise.resolve( response ) );
 }
 
 export function fetchConversionInfo() {
-	return apiFetch({
+	return apiFetch( {
 		path: NEWSPACK_CONVERTER_API_BASE_URL + '/conversion/get-info',
-	}).then(response => Promise.resolve(response));
+	} ).then( response => Promise.resolve( response ) );
 }
 
 export function postConversionInitialize() {
-	return apiFetch({
+	return apiFetch( {
 		path: NEWSPACK_CONVERTER_API_BASE_URL + '/conversion/initialize',
-	}).then(response => Promise.resolve(response));
+	} ).then( response => Promise.resolve( response ) );
 }
 
 export function fetchPatchingInfo() {
-	return apiFetch({
+	return apiFetch( {
 		path: NEWSPACK_CONVERTER_API_BASE_URL + '/patching/get-info',
-	}).then(response => Promise.resolve(response));
+	} ).then( response => Promise.resolve( response ) );
 }
 
 export function postPatchingInitialize() {
-	return apiFetch({
+	return apiFetch( {
 		path: NEWSPACK_CONVERTER_API_BASE_URL + '/patching/initialize',
-	}).then(response => Promise.resolve(response));
+	} ).then( response => Promise.resolve( response ) );
 }
 
 export function callPatchingProcessNextBatch() {
-	return apiFetch({
+	return apiFetch( {
 		path: NEWSPACK_CONVERTER_API_BASE_URL + '/patching/process-next-batch',
-	}).then(response => Promise.resolve(response));
+	} ).then( response => Promise.resolve( response ) );
 }
 
 export default {

--- a/dependency-includer-script.php
+++ b/dependency-includer-script.php
@@ -1,11 +1,11 @@
 <?php
 /**
  * Dependency includer script.
- * TODO: use Composer autoloading instead of this.
  *
  * @package Newspack
  */
 
+// TODO: Switch to Composer autoloading and remove this file all together.
 require_once dirname( __FILE__ ) . '/lib/class-config.php';
 require_once dirname( __FILE__ ) . '/lib/class-converter.php';
 require_once dirname( __FILE__ ) . '/lib/class-convertercontroller.php';

--- a/lib/class-converter.php
+++ b/lib/class-converter.php
@@ -191,7 +191,7 @@ class Converter {
 
 		return (
 			'post-new.php' === $pagenow &&
-			isset( $_GET['newspack-content-converter'] )
+			isset( $_GET['newspack-content-converter'] ) // phpcs:ignore
 		);
 	}
 }

--- a/lib/class-convertercontroller.php
+++ b/lib/class-convertercontroller.php
@@ -163,13 +163,15 @@ class ConverterController extends WP_REST_Controller {
 	 * @return array Info for the settings page.
 	 */
 	public function settings_get_info() {
-		return rest_ensure_response( [
-			'conversionContentTypesCsv'    => $this->conversion_processor->get_conversion_content_types(),
-			'conversionContentStatusesCsv' => $this->conversion_processor->get_conversion_content_statuses(),
-			'conversionBatchSize'          => $this->conversion_processor->get_conversion_batch_size(),
-			'patchingBatchSize'            => $this->conversion_processor->get_patching_batch_size(),
-			'queuedEntries'                => $this->conversion_processor->get_queued_entries_total_number(),
-		] );
+		return rest_ensure_response(
+			[
+				'conversionContentTypesCsv'    => $this->conversion_processor->get_conversion_content_types(),
+				'conversionContentStatusesCsv' => $this->conversion_processor->get_conversion_content_statuses(),
+				'conversionBatchSize'          => $this->conversion_processor->get_conversion_batch_size(),
+				'patchingBatchSize'            => $this->conversion_processor->get_patching_batch_size(),
+				'queuedEntries'                => $this->conversion_processor->get_queued_entries_total_number(),
+			]
+		);
 	}
 
 	/**
@@ -179,21 +181,22 @@ class ConverterController extends WP_REST_Controller {
 	 * @return array Info for the settings page.
 	 */
 	public function conversion_get_info() {
-		return rest_ensure_response( [
-			'isConversionOngoing' => $this->conversion_processor->is_conversion_queued() ? '1' : '0',
-			'queuedEntries'       => $this->conversion_processor->get_queued_entries_total_number(),
-			'conversionBatchSize' => $this->conversion_processor->get_conversion_batch_size(),
-			'queuedBatches'       => $this->conversion_processor->get_conversion_queued_batches(),
-			'maxBatch'            => $this->conversion_processor->get_conversion_max_batch(),
-		] );
+		return rest_ensure_response(
+			[
+				'isConversionOngoing' => $this->conversion_processor->is_conversion_queued() ? '1' : '0',
+				'queuedEntries'       => $this->conversion_processor->get_queued_entries_total_number(),
+				'conversionBatchSize' => $this->conversion_processor->get_conversion_batch_size(),
+				'queuedBatches'       => $this->conversion_processor->get_conversion_queued_batches(),
+				'maxBatch'            => $this->conversion_processor->get_conversion_max_batch(),
+			]
+		);
 	}
 
 	/**
 	 * Callback for the /conversion/initialize route.
 	 * Initializes the conversion queue.
 	 *
-	 * @param WP_REST_Request $params JSON param, key 'request' with value 'initialize'.
-	 * @return array Formatted response.
+	 * @return array Null or formatted response -- key 'result', value 'queued'.
 	 */
 	public function conversion_initialize() {
 		$initialized = $this->conversion_processor->initialize_conversion();
@@ -208,11 +211,13 @@ class ConverterController extends WP_REST_Controller {
 	 * @return array Conversion batch data.
 	 */
 	public function conversion_get_batch_data() {
-		return rest_ensure_response( [
-			'ids'       => $this->conversion_processor->set_next_conversion_batch_to_queue(),
-			'thisBatch' => max( $this->conversion_processor->get_conversion_queued_batches() ),
-			'maxBatch'  => $this->conversion_processor->get_conversion_max_batch(),
-		] );
+		return rest_ensure_response(
+			[
+				'ids'       => $this->conversion_processor->set_next_conversion_batch_to_queue(),
+				'thisBatch' => max( $this->conversion_processor->get_conversion_queued_batches() ),
+				'maxBatch'  => $this->conversion_processor->get_conversion_max_batch(),
+			]
+		);
 	}
 
 	/**
@@ -222,13 +227,15 @@ class ConverterController extends WP_REST_Controller {
 	 * @return array Info for the patching page.
 	 */
 	public function patching_get_info() {
-		return rest_ensure_response( [
-			'isPatchingOngoing'        => $this->conversion_processor->is_patching_queued(),
-			'queuedBatchesPatching'    => $this->conversion_processor->get_patching_queued_batches(),
-			'maxBatchPatching'         => $this->conversion_processor->get_patching_max_batch(),
-			'patchingBatchSize'        => $this->conversion_processor->get_patching_batch_size(),
-			'queuedEntries'            => $this->conversion_processor->get_queued_entries_total_number(),
-		] );
+		return rest_ensure_response(
+			[
+				'isPatchingOngoing'     => $this->conversion_processor->is_patching_queued(),
+				'queuedBatchesPatching' => $this->conversion_processor->get_patching_queued_batches(),
+				'maxBatchPatching'      => $this->conversion_processor->get_patching_max_batch(),
+				'patchingBatchSize'     => $this->conversion_processor->get_patching_batch_size(),
+				'queuedEntries'         => $this->conversion_processor->get_queued_entries_total_number(),
+			]
+		);
 
 	}
 
@@ -236,8 +243,7 @@ class ConverterController extends WP_REST_Controller {
 	 * Callback for the /patching/initialize route.
 	 * Initializes patching.
 	 *
-	 * @param WP_REST_Request $params JSON param, key 'request' with value 'initialize'.
-	 * @return array Formatted response.
+	 * @return array Null or formatted response -- key 'result', value 'queued'.
 	 */
 	public function patching_initialize() {
 		$initialized = $this->conversion_processor->initialize_patching();
@@ -266,9 +272,11 @@ class ConverterController extends WP_REST_Controller {
 			return;
 		}
 
-		return rest_ensure_response( [
-			'result' => 'patched',
-		] );
+		return rest_ensure_response(
+			[
+				'result' => 'patched',
+			]
+		);
 	}
 
 	/**
@@ -279,7 +287,7 @@ class ConverterController extends WP_REST_Controller {
 	 * @return array Post content.
 	 */
 	public function get_post_content_by_id( $params ) {
-		$post_id     = $params['id'];
+		$post_id = $params['id'];
 
 		return rest_ensure_response( $this->conversion_processor->get_post_content_by_id( $post_id ) );
 	}

--- a/lib/class-installer.php
+++ b/lib/class-installer.php
@@ -101,6 +101,7 @@ class Installer {
 	) $charset_collate;";
 
 		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+		// phpcs:ignore -- allow DB modification for custom table.
 		dbDelta( $sql );
 	}
 
@@ -113,6 +114,7 @@ class Installer {
 		global $wpdb;
 
 		$table_name_esc = esc_sql( $table_name );
+		// phpcs:ignore -- allow this direct DB call; the table name is escaped.
 		$wpdb->query( "DROP TABLE IF EXISTS {$table_name_esc};" );
 	}
 
@@ -125,6 +127,7 @@ class Installer {
 	private static function get_post_types_editable_by_block_editor() {
 		$post_types = get_post_types( array( 'public' => true ) );
 
+		// phpcsignore -- ignore warning, allow following comment with valid code.
 		// Attempt to use use_block_editor_for_post_type() function, or else default to 'post' and 'page'.
 		require_once ABSPATH . 'wp-admin/includes/post.php';
 		if ( function_exists( 'use_block_editor_for_post_type' ) ) {
@@ -170,11 +173,13 @@ class Installer {
 									  SELECT {$wp_posts_columns_csv}
 									  FROM {$wp_posts_table}
 									  WHERE post_status IN ({$statuses_placeholders_csv})
-									  AND post_type IN ({$type_placeholders_csv}) 
+									  AND post_type IN ({$type_placeholders_csv})
 									  AND post_content <> '' ;";
+		// phpcs:ignore -- false positive, all params are fully sanitized.
 		$wpdb->get_results( $wpdb->prepare( $sql_placeholders, array_merge( $post_statuses, $post_types ) ) );
 
 		// Insert specified content into plugin's table.
+		// phpcs:ignore -- the following is a false positive; this SQL is safe, and the table name is escaped above.
 		$results       = $wpdb->get_results( "SELECT COUNT(*) AS total FROM {$table_name} ; " );
 		$total_entries = isset( $results[0]->total ) ? (int) $results[0]->total : false;
 
@@ -259,12 +264,13 @@ class Installer {
 
 		$table_name = esc_sql( $table_name );
 
+		// phpcs:ignore -- OK to use a direct DB call here.
 		$results = $wpdb->get_results(
 			$wpdb->prepare(
-				'SELECT * 
-		         FROM INFORMATION_SCHEMA.TABLES 
-		         WHERE TABLE_SCHEMA = %s 
-		         AND  TABLE_NAME = %s;',
+				'SELECT *
+		         FROM INFORMATION_SCHEMA.TABLES
+		         WHERE TABLE_SCHEMA = %s
+		         AND TABLE_NAME = %s;',
 				$wpdb->dbname,
 				$table_name
 			)

--- a/lib/content-patcher/patchers/class-imgpatcher.php
+++ b/lib/content-patcher/patchers/class-imgpatcher.php
@@ -220,7 +220,7 @@ class ImgPatcher extends PatcherAbstract implements PatcherInterface {
 		// patch (replace) attribute value.
 		$attributes_json                    = json_decode( $attributes, true );
 		$attributes_json[ $attribute_name ] = $attribute_value;
-		$attributes_patched                 = json_encode( $attributes_json, JSON_NUMERIC_CHECK );
+		$attributes_patched                 = wp_json_encode( $attributes_json, JSON_NUMERIC_CHECK );
 
 		// put back patched attributes.
 		if ( isset( $existing_attributes ) ) {


### PR DESCRIPTION
Fixes #34 

- applied `.prettierrc` standards to all `.js`, `.css`, `.scss`,
- applied PHPCS standards and fixed and addressed all issues.

No particular logic changes made in this PR besides those directly pointed out by the prettifiers:
- removed several uses of `var` and substituted with `const`/`let`,
- used `$wpdb->prepare` with placeholders wherever possible.