### PR TITLE
Skip converting invalid content

### DIFF
--- a/assets/src/index.js
+++ b/assets/src/index.js
@@ -39,7 +39,7 @@ function nccCallbackWithRetry( callback, callbackParam, maxAttempts = 10, timeou
 				resolve();
 			} catch ( e ) {
 				if ( 0 == attempt ) {
-					console.log( 'Final error: ' + e );
+					console.log( 'Final CSS warning: ' + e );
 				} else {
 					setTimeout( function() {
 						doCallback( attempt - 1 );

--- a/lib/class-convertercontroller.php
+++ b/lib/class-convertercontroller.php
@@ -271,11 +271,13 @@ class ConverterController extends WP_REST_Controller {
 	public function get_conversion_batch_data() {
 		$ids                        = $this->conversion_processor->set_next_conversion_batch_to_queue();
 		$has_incomplete_conversions = ! $this->conversion_processor->is_queued_conversion() && $this->conversion_processor->has_incomplete_conversions();
+		$queued_batches             = $this->conversion_processor->get_conversion_queued_batches();
+		$this_batch                 = ! empty( $queued_batches ) ? max( $queued_batches ) : null;
 
 		return rest_ensure_response(
 			[
 				'ids'                      => $ids,
-				'thisBatch'                => max( $this->conversion_processor->get_conversion_queued_batches() ),
+				'thisBatch'                => $this_batch,
 				'maxBatch'                 => $this->conversion_processor->get_conversion_max_batch(),
 				'hasIncompleteConversions' => $has_incomplete_conversions,
 			]

--- a/newspack-content-converter.php
+++ b/newspack-content-converter.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Newspack Content Converter
  * Description: Mass converts pre-Gutenberg HTML content to Gutenberg Blocks.
- * Version: 0.0.7-alpha
+ * Version: 0.0.8-alpha
  * Author: Automattic
  * Author URI: https://newspack.blog/
  * License: GPL2


### PR DESCRIPTION
Fixes #29 
Depends on #36 

During plugin Activation, the table `ncc_wp_posts` is created, and entries from the `wp_posts` table are inserted into it. This PR makes sure that the following types of posts aren't queued for conversion:
- posts with blank content (totally empty, or containing only white spaces, or line breaks), since they break with error in Gutenberg during conversion,
- posts which already have block contents, since another pass at conversion may ruin the content.

So we need some test data which needs to consist of:
- HTML posts
- posts with blocks content
- posts with different cases of blank contents -- blank spaces, html encoded blank spaces, line breaks

Since this test data might a bit difficult to create, to make this testing simpler I generated a test `wp_posts` table to be imported here in the next step -- [wp_posts.sql](https://drive.google.com/file/d/1XfLEDZJp3lwsTVGpcByckUMEpOe3HKjt/view?usp=sharing) which contains:
- 140 posts with blocks content
- 140 posts with HTML content
- 20 posts with various cases of empty contents

### 1. Import test data
Before Activating the plugin, we need to import the test data:
- first run `TRUNCATE wp_posts;`
- then import the [wp_posts.sql](https://drive.google.com/file/d/1XfLEDZJp3lwsTVGpcByckUMEpOe3HKjt/view?usp=sharing) either from your DB client, or from the CLI `ssh` into vagrant, then run `mysql {DB_NAME} < wp_posts.sql`

### 2. Build and Activate the plugin
- if the Plugin's already installed, first Deactivate & Delete it, then pull this branch and build it with `nvm use 10.10.0 && npm ci && npm run clean && npm run build:webpack`, and lastly Activate the plugin
- additionally, if you're using a symlink to the Plugin's folder in your local env, and it may not be convenient for you to have to recreate the symlink after fully Deleting the plugin, feel free to pull, build and Activate according to [these instructions](https://github.com/Automattic/newspack-content-converter/pull/33#pullrequestreview-337412481) -- follow steps 1. and 2.

### 3. Check the results
If you used the SQL file above, there was a total of 140 non-empty posts with HTML content. Go to WP-admin > Newspack Content Converter > Run Conversion, and see that the page says "number of posts/entries to be converted: 140".
You can also check that the total number of entries in the `ncc_wp_posts` is 140 with `select count(*) from ncc_wp_posts;` and additionally that and the all rows contain only HTML in the `post_content` column.