### PR TITLE
Reorder admin pages to display "Run conversion" first

### DIFF
--- a/assets/src/content-converter/index.js
+++ b/assets/src/content-converter/index.js
@@ -117,7 +117,7 @@ class ContentConverter extends Component {
 					<h1>{ __( 'Content Conversion Complete' ) }</h1>
 					<p>{ __( 'All queued content has been converted.' ) }</p>
 					<p>
-						<a href="/wp-admin/admin.php?page=ncc-conversion">
+						<a href="/wp-admin/admin.php?page=newspack-content-converter">
 							{ __( 'Back to Run Conversion page' ) }
 						</a>
 					</p>

--- a/assets/src/conversion/index.js
+++ b/assets/src/conversion/index.js
@@ -143,11 +143,11 @@ class Conversion extends Component {
 								) }
 								isWarning
 							/>
-							<Card noBackground className="newspack-card__buttons-card">
+							<div className="newspack-buttons-card">
 								<Button isPrimary onClick={ this.handleOnClickResetConversion }>
 									{ __( 'Reset conversion' ) }
 								</Button>
-							</Card>
+							</div>
 						</Card>
 					</Grid>
 				</Fragment>
@@ -206,11 +206,14 @@ class Conversion extends Component {
 								) }
 								isWarning
 							/>
-							<Card noBackground className="newspack-card__buttons-card">
+							<div className="newspack-buttons-card">
 								<Button isPrimary onClick={ this.handleOnClickInitializeConversion }>
-									{ __( 'Start conversion' ) }
+									{ __( 'Run conversion' ) }
 								</Button>
-							</Card>
+								<Button isSecondary href="/wp-admin/admin.php?page=newspack-content-converter-settings">
+									{ __( 'Settings' ) }
+								</Button>
+							</div>
 						</Card>
 					</Grid>
 				</Fragment>

--- a/assets/src/conversion/index.js
+++ b/assets/src/conversion/index.js
@@ -210,7 +210,10 @@ class Conversion extends Component {
 								<Button isPrimary onClick={ this.handleOnClickInitializeConversion }>
 									{ __( 'Run conversion' ) }
 								</Button>
-								<Button isSecondary href="/wp-admin/admin.php?page=newspack-content-converter-settings">
+								<Button
+									isSecondary
+									href="/wp-admin/admin.php?page=newspack-content-converter-settings"
+								>
 									{ __( 'Settings' ) }
 								</Button>
 							</div>

--- a/assets/src/settings/index.js
+++ b/assets/src/settings/index.js
@@ -7,7 +7,14 @@ import { __ } from '@wordpress/i18n';
 /**
  * Newspack dependencies.
  */
-import { Button, Card, FormattedHeader, Grid, NewspackLogo, TextControl } from 'newspack-components';
+import {
+	Button,
+	Card,
+	FormattedHeader,
+	Grid,
+	NewspackLogo,
+	TextControl,
+} from 'newspack-components';
 
 /**
  * Material UI dependencies.
@@ -35,10 +42,7 @@ class Settings extends Component {
 	componentDidMount() {
 		return fetchSettingsInfo().then( response => {
 			if ( response ) {
-				const {
-					conversionContentTypesCsv,
-					conversionContentStatusesCsv,
-				} = response;
+				const { conversionContentTypesCsv, conversionContentStatusesCsv } = response;
 				this.setState( {
 					conversionContentTypesCsv,
 					conversionContentStatusesCsv,
@@ -52,10 +56,7 @@ class Settings extends Component {
 	 * render().
 	 */
 	render() {
-		const {
-			conversionContentTypesCsv,
-			conversionContentStatusesCsv,
-		} = this.state;
+		const { conversionContentTypesCsv, conversionContentStatusesCsv } = this.state;
 
 		return (
 			<Fragment>
@@ -69,7 +70,11 @@ class Settings extends Component {
 						subHeaderText={ __( 'Adding content to the queue to convert it to Gutenberg blocks.' ) }
 					/>
 					<Card>
-						<p>{ __( 'The type of HTML content to be converted to Gutenberg blocks is specified here.' ) }</p>
+						<p>
+							{ __(
+								'The type of HTML content to be converted to Gutenberg blocks is specified here.'
+							) }
+						</p>
 						<TextControl
 							label={ __( 'Content types' ) }
 							disabled={ true }

--- a/assets/src/settings/index.js
+++ b/assets/src/settings/index.js
@@ -65,13 +65,11 @@ class Settings extends Component {
 				<Grid>
 					<FormattedHeader
 						headerIcon={ <SettingsIcon /> }
-						headerText={ __( 'Conversion settings' ) }
+						headerText={ __( 'Settings' ) }
 						subHeaderText={ __( 'Adding content to the queue to convert it to Gutenberg blocks.' ) }
 					/>
 					<Card>
 						<p>{ __( 'The type of HTML content to be converted to Gutenberg blocks is specified here.' ) }</p>
-						<hr />
-						<h2 id="content-type">{ __( 'Content type' ) }</h2>
 						<TextControl
 							label={ __( 'Content types' ) }
 							disabled={ true }
@@ -82,14 +80,11 @@ class Settings extends Component {
 							disabled={ true }
 							value={ conversionContentStatusesCsv }
 						/>
-						<p>
-							<Button
-								isPrimary
-								href="/wp-admin/admin.php?page=ncc-conversion"
-							>
+						<div className="newspack-buttons-card">
+							<Button isPrimary href="/wp-admin/admin.php?page=newspack-content-converter">
 								{ __( 'Run conversion' ) }
 							</Button>
-						</p>
+						</div>
 					</Card>
 				</Grid>
 			</Fragment>

--- a/lib/class-converter.php
+++ b/lib/class-converter.php
@@ -74,12 +74,12 @@ class Converter {
 			function () {
 
 				add_menu_page(
-					__( 'Newspack Content Converter' ),
+					__( 'Run conversion' ),
 					__( 'Newspack Content Converter' ),
 					'manage_options',
 					'newspack-content-converter',
 					function () {
-						echo '<div id="ncc-settings"></div>';
+						echo '<div id="ncc-conversion"></div>';
 					},
 					'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB3aWR0aD0iMjQiIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiBkPSJNMjAuNTUgNS4yMmwtMS4zOS0xLjY4QzE4Ljg4IDMuMjEgMTguNDcgMyAxOCAzSDZjLS40NyAwLS44OC4yMS0xLjE1LjU1TDMuNDYgNS4yMkMzLjE3IDUuNTcgMyA2LjAxIDMgNi41VjE5YzAgMS4xLjg5IDIgMiAyaDE0YzEuMSAwIDItLjkgMi0yVjYuNWMwLS40OS0uMTctLjkzLS40NS0xLjI4ek0xMiA5LjVsNS41IDUuNUgxNHYyaC00di0ySDYuNUwxMiA5LjV6TTUuMTIgNWwuODItMWgxMmwuOTMgMUg1LjEyeiIgZmlsbD0iY3VycmVudGNvbG9yIi8+PC9zdmc+Cg=='
 				);
@@ -89,9 +89,20 @@ class Converter {
 					__( 'Run conversion' ),
 					__( 'Run conversion' ),
 					'manage_options',
-					'ncc-conversion',
+					'newspack-content-converter',
 					function () {
 						echo '<div id="ncc-conversion"></div>';
+					}
+				);
+
+				add_submenu_page(
+					'newspack-content-converter',
+					__( 'Settings' ),
+					__( 'Settings' ),
+					'manage_options',
+					'newspack-content-converter-settings',
+					function () {
+						echo '<div id="ncc-settings"></div>';
 					}
 				);
 


### PR DESCRIPTION
The main purpose of the plugin is to convert content to Gutenberg blocks.

At the moment when you click on "Newspack Content Converter" you see the "Settings". This PR changes the order with the "Run conversion" being the first screen a user will see, and a submenu item for "Settings".

