### PR TITLE
Content Converter: Update interface based on Newspack Components

### DIFF
--- a/assets/src/content-converter/index.js
+++ b/assets/src/content-converter/index.js
@@ -1,8 +1,27 @@
 /**
  * WordPress dependencies.
  */
-import { Component } from '@wordpress/element';
+import { Component, Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+
+/**
+ * Newspack dependencies.
+ */
+import {
+	Button,
+	Card,
+	FormattedHeader,
+	Grid,
+	NewspackLogo,
+	Notice,
+	Waiting,
+} from 'newspack-components';
+
+/**
+ * Material UI dependencies.
+ */
+import ArrowBackIcon from '@material-ui/icons/ArrowBack';
+import UnarchiveIcon from '@material-ui/icons/Unarchive';
 
 /**
  * Internal dependencies.
@@ -83,51 +102,92 @@ class ContentConverter extends Component {
 
 		if ( null == isActive ) {
 			return (
-				<div className="ncc-page">
-					<h1>{ __( 'Content Conversion' ) }</h1>
-					<img src="/wp-admin/images/wpspin_light.gif" /> Loading...
+				<div className="newspack-content-converter__wrapper">
+					<div className="newspack-logo-wrapper">
+						<NewspackLogo />
+					</div>
+					<Grid>
+						<FormattedHeader
+							headerIcon={ <UnarchiveIcon /> }
+							headerText={ __( 'Conversion' ) }
+							subHeaderText={ __( 'Conversion to Gutenberg blocks is in progress.' ) }
+						/>
+						<Card>
+							<div className="newspack-content-converter__status">
+								<Waiting isLeft />
+								{ __( 'Loading...' ) }
+							</div>
+						</Card>
+					</Grid>
 				</div>
 			);
 		} else if ( true == isActive ) {
 			return (
-				<div className="ncc-page">
-					<h1>{ __( 'Content Conversion...' ) }</h1>
-					<img src="/wp-admin/images/wpspin_light.gif" />
-					&nbsp; { __( 'Now processing batch' ) } { thisBatch }/{ maxBatch } ...
-					<br />
-					<h3>{ __( 'Do not close this page!' ) }</h3>
-					<ul>
-						<li>
-							{ __(
-								'This page will occasionally automatically reload, and notify you when the conversion is complete.'
-							) }
-						</li>
-						<li>{ __( 'If asked to Reload, chose yes.' ) }</li>
-						<li>
-							{ __(
-								'You may also carefully open an additional tab to convert another batch in parallel.'
-							) }
-						</li>
-					</ul>
+				<div className="newspack-content-converter__wrapper newspack-content-converter__is-active">
+					<div className="newspack-logo-wrapper">
+						<NewspackLogo />
+					</div>
+					<Grid>
+						<FormattedHeader
+							headerIcon={ <UnarchiveIcon /> }
+							headerText={ __( 'Conversion' ) }
+							subHeaderText={ __( 'Conversion to Gutenberg blocks is in progress.' ) }
+						/>
+						<Card>
+							<h2>{ __( 'Do not close this page!' ) }</h2>
+							<div className="newspack-content-converter__status">
+								<Waiting isLeft />
+								{ __( 'Now processing batch' ) } { thisBatch }/{ maxBatch }...
+							</div>
+							<p>
+								{ __(
+									'This page will occasionally automatically reload, and notify you when the conversion is complete.'
+								) }
+							</p>
+							<p>{ __( 'If asked to Reload, chose yes.' ) }</p>
+							<Notice
+								noticeText={ __(
+									'You may also carefully open an additional tab to convert another batch in parallel.'
+								) }
+								isPrimary
+							/>
+						</Card>
+					</Grid>
 				</div>
 			);
 		} else if ( false == isActive ) {
 			return (
-				<div className="ncc-page">
-					<h1>{ __( 'Content Conversion Complete' ) }</h1>
-					<p>{ __( 'All queued content has been converted.' ) }</p>
-					<p>
-						<a href="/wp-admin/admin.php?page=newspack-content-converter">
-							{ __( 'Back to Run Conversion page' ) }
-						</a>
-					</p>
-					{ true == hasIncompleteConversions && (
-						<p>
-							{ __(
-								'Warning: certain posts were not converted successfully. You may try converting those again on the Run Conversion page.'
+				<div className="newspack-content-converter__wrapper">
+					<div className="newspack-logo-wrapper">
+						<NewspackLogo />
+					</div>
+					<Grid>
+						<FormattedHeader
+							headerIcon={ <UnarchiveIcon /> }
+							headerText={ __( 'Conversion' ) }
+							subHeaderText={ __( 'Conversion to Gutenberg blocks is complete.' ) }
+						/>
+						<Card>
+							{ true == hasIncompleteConversions ? (
+								<Notice
+									noticeText={ __(
+										'Certain entries were not converted successfully. You may try converting those again on the Run conversion page.'
+									) }
+									isError
+								/>
+							) : (
+								<Notice
+									noticeText={ __( 'All queued content has been converted successfully.' ) }
+									isSuccess
+								/>
 							) }
-						</p>
-					) }
+							<div className="newspack-buttons-card">
+								<Button href="/wp-admin/admin.php?page=newspack-content-converter" isPrimary>
+									{ __( 'Back to Run conversion' ) }
+								</Button>
+							</div>
+						</Card>
+					</Grid>
 				</div>
 			);
 		}

--- a/assets/src/style.scss
+++ b/assets/src/style.scss
@@ -51,6 +51,16 @@ body[class*="newspack-content-converter_"] {
 
 // Wrapper
 .newspack-content-converter__wrapper {
+	bottom: 0;
+	display: flex;
+	flex-direction: column;
+	left: 0;
+	overflow-y: auto;
+	position: absolute;
+	right: 0;
+	top: 0;
+	z-index: 9999;
+
 	&:before {
 		background: $primary-500;
 		bottom: 0;
@@ -58,9 +68,20 @@ body[class*="newspack-content-converter_"] {
 		display: block;
 		left: 0;
 		min-height: 100vh;
-		position: absolute;
+		position: fixed;
 		right: 0;
 		top: 0;
+		z-index: -1;
+	}
+
+	.newspack-logo-wrapper {
+		margin-bottom: 32px;
+	}
+
+	.newspack-grid {
+		flex: 1 1 100%;
+		padding-bottom: 32px;
+		width: 100%;
 	}
 
 	&.newspack-content-converter__is-active {

--- a/assets/src/style.scss
+++ b/assets/src/style.scss
@@ -1,3 +1,5 @@
+@import '~newspack-components/shared/scss/colors';
+
 .toplevel_page_newspack-content-converter,
 body[class*="newspack-content-converter_"] {
 	#wpcontent {
@@ -44,5 +46,79 @@ body[class*="newspack-content-converter_"] {
 		justify-content: center;
 		margin-left: 8px;
 		padding: 0;
+	}
+}
+
+// Wrapper
+.newspack-content-converter__wrapper {
+	&:before {
+		background: $primary-500;
+		bottom: 0;
+		content: "";
+		display: block;
+		left: 0;
+		min-height: 100vh;
+		position: absolute;
+		right: 0;
+		top: 0;
+	}
+
+	&.newspack-content-converter__is-active {
+		cursor: wait;
+
+		.newspack-card {
+			position: relative;
+
+			&:before {
+				animation: newspack-content-converter__is-active-animation 2s ease-in-out infinite;
+				background: $primary-800;
+				content: "";
+				display: block;
+				height: 4px;
+				left: 0;
+				position: absolute;
+				right: 100%;
+				top: 0;
+				z-index: 1;
+			}
+		}
+	}
+
+	> * {
+		position: relative;
+	}
+
+	.newspack-formatted-header {
+		.newspack-formatted-header__title,
+		.newspack-formatted-header__subtitle {
+			color: white;
+		}
+
+		.newspack-formatted-header__icon svg {
+			fill: white;
+		}
+	}
+}
+
+// Status
+.newspack-content-converter__status {
+	align-items: center;
+	display: flex;
+}
+
+@keyframes newspack-content-converter__is-active-animation {
+	from {
+		left: 0;
+		right: 100%;
+	}
+
+	50% {
+		left: 0;
+		right: 0;
+	}
+
+	to {
+		left: 100%;
+		right: 0;
 	}
 }


### PR DESCRIPTION
This PR brings `newspack-components` to the actual conversion page.

It uses the Blue background to emphasise its uniqueness and distinguish it from the setting/run conversion pages.

Note: there's an issue where vertical scrolling doesn't work and small screen don't have access to the entire content -- still looking for a solution.