### PR TITLE
feat: wp-cli command to reset db tables

### DIFF
--- a/dependency-includer-script.php
+++ b/dependency-includer-script.php
@@ -26,3 +26,6 @@ require_once dirname( __FILE__ ) . '/lib/content-patcher/patchers/class-shortcod
 require_once dirname( __FILE__ ) . '/lib/content-patcher/elementManipulators/class-htmlelementmanipulator.php';
 require_once dirname( __FILE__ ) . '/lib/content-patcher/elementManipulators/class-squarebracketselementmanipulator.php';
 require_once dirname( __FILE__ ) . '/lib/content-patcher/elementManipulators/class-wpblockmanipulator.php';
+if ( defined( 'WP_CLI' ) && WP_CLI ) {
+	require_once dirname( __FILE__ ) . '/lib/class-cli.php';
+}

--- a/lib/class-cli.php
+++ b/lib/class-cli.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * WP-CLI integration.
+ *
+ * @package Newspack
+ */
+
+namespace NewspackContentConverter;
+
+/**
+ * Class Config
+ *
+ * @package NewspackContentConverter
+ */
+class CLI {
+
+	/**
+	 * Singleton instance.
+	 *
+	 * @var Config
+	 */
+	private static $instance;
+
+	/**
+	 * Config constructor.
+	 */
+	public function __construct() {
+		\WP_CLI::add_command( 'newspack-content-converter reset', [ $this, 'cli_reset' ] );
+	}
+
+	/**
+	 * Reset the Newspack Content Converter tables. This action is equivalent to uninstalling, deleting, and reinstaalling the plugin.
+	 */
+	public static function cli_reset() {
+		\NewspackContentConverter\Installer::uninstall_plugin( true );
+		\WP_CLI::line( __( 'Uninstallation complete.', 'newspack-content-converter' ) );
+		\NewspackContentConverter\Installer::install_plugin( true );
+		\WP_CLI::line( __( 'Installation complete.', 'newspack-content-converter' ) );
+		\WP_CLI::success( 'Reset complete.' );
+	}
+}
+new \NewspackContentConverter\CLI();

--- a/lib/class-installer.php
+++ b/lib/class-installer.php
@@ -42,8 +42,8 @@ class Installer {
 	 * Plugin uninstallation.
 	 * Drops the plugin table, deleted plugin options.
 	 */
-	public static function uninstall_plugin() {
-		if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
+	public static function uninstall_plugin( $override = false ) {
+		if ( ! $override && ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 			exit();
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds a WP-CLI command that resets the database tables. The action is equivalent to uninstalling, deleting, reinstalling and activating the plugin.

### How to test the changes in this Pull Request:

1. `wp newspack-content-converter reset`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
