### PR TITLE
Update overall design by using WordPress components instead of Newspack components

### DIFF
--- a/assets/src/content-converter/index.js
+++ b/assets/src/content-converter/index.js
@@ -105,6 +105,15 @@ class ContentConverter extends Component {
 		if ( null == isActive ) {
 			return (
 				<div className="newspack-content-converter__wrapper">
+					<div className="newspack-logo__wrapper">
+						<Button
+							href="https://newspack.pub/"
+							target="_blank"
+							label={ __( 'By Newspack' ) }
+						>
+							<NewspackLogo />
+						</Button>
+					</div>
 					<Card>
 						<CardHeader isShady>
 							<FlexBlock>
@@ -116,6 +125,11 @@ class ContentConverter extends Component {
 							<Spinner />
 						</CardFooter>
 					</Card>
+				</div>
+			);
+		} else if ( true == isActive ) {
+			return (
+				<div className="newspack-content-converter__wrapper is-active">
 					<div className="newspack-logo__wrapper">
 						<Button
 							href="https://newspack.pub/"
@@ -125,11 +139,6 @@ class ContentConverter extends Component {
 							<NewspackLogo />
 						</Button>
 					</div>
-				</div>
-			);
-		} else if ( true == isActive ) {
-			return (
-				<div className="newspack-content-converter__wrapper is-active">
 					<Card>
 						<CardHeader isShady>
 							<FlexBlock>
@@ -158,6 +167,11 @@ class ContentConverter extends Component {
 								<p>{ __( 'Now processing batch' ) } { thisBatch }/{ maxBatch }</p>
 						</CardFooter>
 					</Card>
+				</div>
+			);
+		} else if ( false == isActive ) {
+			return (
+				<div className="newspack-content-converter__wrapper">
 					<div className="newspack-logo__wrapper">
 						<Button
 							href="https://newspack.pub/"
@@ -167,11 +181,6 @@ class ContentConverter extends Component {
 							<NewspackLogo />
 						</Button>
 					</div>
-				</div>
-			);
-		} else if ( false == isActive ) {
-			return (
-				<div className="newspack-content-converter__wrapper">
 					<Card>
 						<CardHeader isShady>
 							<FlexBlock>
@@ -212,15 +221,6 @@ class ContentConverter extends Component {
 							</CardFooter>
 						) }
 					</Card>
-					<div className="newspack-logo__wrapper">
-						<Button
-							href="https://newspack.pub/"
-							target="_blank"
-							label={ __( 'By Newspack' ) }
-						>
-							<NewspackLogo />
-						</Button>
-					</div>
 				</div>
 			);
 		}

--- a/assets/src/content-converter/index.js
+++ b/assets/src/content-converter/index.js
@@ -3,19 +3,21 @@
  */
 import { Component, Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import {
+	Button,
+	Card,
+	CardBody,
+	CardFooter,
+	CardHeader,
+	FlexBlock,
+	Notice,
+	Spinner
+} from '@wordpress/components';
 
 /**
  * Newspack dependencies.
  */
-import {
-	Button,
-	Card,
-	FormattedHeader,
-	Grid,
-	NewspackLogo,
-	Notice,
-	Waiting,
-} from 'newspack-components';
+import { NewspackLogo } from 'newspack-components';
 
 /**
  * Material UI dependencies.
@@ -103,91 +105,122 @@ class ContentConverter extends Component {
 		if ( null == isActive ) {
 			return (
 				<div className="newspack-content-converter__wrapper">
-					<div className="newspack-logo-wrapper">
-						<NewspackLogo />
+					<Card>
+						<CardHeader isShady>
+							<FlexBlock>
+								<h2>{ __( 'Converting...' ) }</h2>
+								<p>{ __( 'Conversion to Gutenberg blocks is in progress' ) }</p>
+							</FlexBlock>
+						</CardHeader>
+						<CardFooter justify="center" isBorderless>
+							<Spinner />
+						</CardFooter>
+					</Card>
+					<div className="newspack-logo__wrapper">
+						<Button
+							href="https://newspack.pub/"
+							target="_blank"
+							label={ __( 'By Newspack' ) }
+						>
+							<NewspackLogo />
+						</Button>
 					</div>
-					<Grid>
-						<FormattedHeader
-							headerIcon={ <UnarchiveIcon /> }
-							headerText={ __( 'Conversion' ) }
-							subHeaderText={ __( 'Conversion to Gutenberg blocks is in progress.' ) }
-						/>
-						<Card>
-							<div className="newspack-content-converter__status">
-								<Waiting isLeft />
-								{ __( 'Loading...' ) }
-							</div>
-						</Card>
-					</Grid>
 				</div>
 			);
 		} else if ( true == isActive ) {
 			return (
-				<div className="newspack-content-converter__wrapper newspack-content-converter__is-active">
-					<div className="newspack-logo-wrapper">
-						<NewspackLogo />
-					</div>
-					<Grid>
-						<FormattedHeader
-							headerIcon={ <UnarchiveIcon /> }
-							headerText={ __( 'Conversion' ) }
-							subHeaderText={ __( 'Conversion to Gutenberg blocks is in progress.' ) }
-						/>
-						<Card>
-							<h2>{ __( 'Do not close this page!' ) }</h2>
-							<div className="newspack-content-converter__status">
-								<Waiting isLeft />
-								{ __( 'Now processing batch' ) } { thisBatch }/{ maxBatch }...
-							</div>
+				<div className="newspack-content-converter__wrapper is-active">
+					<Card>
+						<CardHeader isShady>
+							<FlexBlock>
+								<h2>{ __( 'Converting...' ) }</h2>
+								<p>{ __( 'Conversion to Gutenberg blocks is in progress' ) }</p>
+							</FlexBlock>
+						</CardHeader>
+						<CardBody>
+							<h4>{ __( 'Do not close this page!' ) }</h4>
 							<p>
 								{ __(
 									'This page will occasionally automatically reload, and notify you when the conversion is complete.'
 								) }
 							</p>
 							<p>{ __( 'If asked to Reload, chose yes.' ) }</p>
-							<Notice
-								noticeText={ __(
-									'You may also carefully open an additional tab to convert another batch in parallel.'
-								) }
-								isPrimary
-							/>
-						</Card>
-					</Grid>
+							<p>
+								<em>
+									{ __(
+										'You may also carefully open an additional tab to convert another batch in parallel.'
+									) }
+								</em>
+							</p>
+						</CardBody>
+						<CardFooter justify="center" className="newspack-content-converter__batch">
+								<Spinner />
+								<p>{ __( 'Now processing batch' ) } { thisBatch }/{ maxBatch }</p>
+						</CardFooter>
+					</Card>
+					<div className="newspack-logo__wrapper">
+						<Button
+							href="https://newspack.pub/"
+							target="_blank"
+							label={ __( 'By Newspack' ) }
+						>
+							<NewspackLogo />
+						</Button>
+					</div>
 				</div>
 			);
 		} else if ( false == isActive ) {
 			return (
 				<div className="newspack-content-converter__wrapper">
-					<div className="newspack-logo-wrapper">
-						<NewspackLogo />
-					</div>
-					<Grid>
-						<FormattedHeader
-							headerIcon={ <UnarchiveIcon /> }
-							headerText={ __( 'Conversion' ) }
-							subHeaderText={ __( 'Conversion to Gutenberg blocks is complete.' ) }
-						/>
-						<Card>
-							{ true == hasIncompleteConversions ? (
-								<Notice
-									noticeText={ __(
-										'Certain entries were not converted successfully. You may try converting those again on the Run conversion page.'
-									) }
-									isError
-								/>
-							) : (
-								<Notice
-									noticeText={ __( 'All queued content has been converted successfully.' ) }
-									isSuccess
-								/>
-							) }
-							<div className="newspack-buttons-card">
-								<Button href="/wp-admin/admin.php?page=newspack-content-converter" isPrimary>
-									{ __( 'Back to Run conversion' ) }
+					<Card>
+						<CardHeader isShady>
+							<FlexBlock>
+								<h2>{ __( 'Finished' ) }</h2>
+								<p>{ __( 'Conversion to Gutenberg blocks is now complete' ) }</p>
+							</FlexBlock>
+						</CardHeader>
+						<CardBody>
+						{ true == hasIncompleteConversions ? (
+							<Notice isDismissible={ false } status="error">
+								{ __(
+									'Certain entries were not converted successfully. You may try converting those again on the "Run conversion" page.'
+								) }
+							</Notice>
+						) : (
+							<Notice isDismissible={ false } status="success">
+								{ __( 'All queued content has been converted successfully.' ) }
+							</Notice>
+						) }
+						</CardBody>
+						{ true == hasIncompleteConversions ? (
+							<CardFooter justify="flex-end">
+								<Button href="/wp-admin/" isSecondary>
+									{ __( 'Back to Dashboard' ) }
 								</Button>
-							</div>
-						</Card>
-					</Grid>
+								<Button href="/wp-admin/admin.php?page=newspack-content-converter" isPrimary>
+									{ __( 'Run Conversion' ) }
+								</Button>
+							</CardFooter>
+						) : (
+							<CardFooter justify="flex-end">
+								<Button href="/wp-admin/admin.php?page=newspack-content-converter" isSecondary>
+									{ __( 'Run Conversion' ) }
+								</Button>
+								<Button href="/wp-admin/" isPrimary>
+									{ __( 'Back to Dashboard' ) }
+								</Button>
+							</CardFooter>
+						) }
+					</Card>
+					<div className="newspack-logo__wrapper">
+						<Button
+							href="https://newspack.pub/"
+							target="_blank"
+							label={ __( 'By Newspack' ) }
+						>
+							<NewspackLogo />
+						</Button>
+					</div>
 				</div>
 			);
 		}

--- a/assets/src/conversion/index.js
+++ b/assets/src/conversion/index.js
@@ -111,6 +111,15 @@ class Conversion extends Component {
 		if ( '1' == isConversionOngoing ) {
 			return (
 				<Fragment>
+					<div className="newspack-logo__wrapper">
+						<Button
+							href="https://newspack.pub/"
+							target="_blank"
+							label={ __( 'By Newspack' ) }
+						>
+							<NewspackLogo />
+						</Button>
+					</div>
 					<Card>
 						<CardHeader isShady>
 							<FlexBlock>
@@ -149,6 +158,11 @@ class Conversion extends Component {
 							</Button>
 						</CardFooter>
 					</Card>
+				</Fragment>
+			);
+		} else {
+			return (
+				<Fragment>
 					<div className="newspack-logo__wrapper">
 						<Button
 							href="https://newspack.pub/"
@@ -158,11 +172,6 @@ class Conversion extends Component {
 							<NewspackLogo />
 						</Button>
 					</div>
-				</Fragment>
-			);
-		} else {
-			return (
-				<Fragment>
 					{ !! someConversionsFailed && (
 						<Card>
 							<CardHeader isShady>
@@ -235,15 +244,6 @@ class Conversion extends Component {
 							</Button>
 						</CardFooter>
 					</Card>
-					<div className="newspack-logo__wrapper">
-						<Button
-							href="https://newspack.pub/"
-							target="_blank"
-							label={ __( 'By Newspack' ) }
-						>
-							<NewspackLogo />
-						</Button>
-					</div>
 				</Fragment>
 			);
 		}

--- a/assets/src/conversion/index.js
+++ b/assets/src/conversion/index.js
@@ -3,24 +3,21 @@
  */
 import { Component, Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import {
+	Button,
+	Card,
+	CardBody,
+	CardFooter,
+	CardHeader,
+	FlexBlock,
+	Notice,
+	TextControl
+} from '@wordpress/components';
 
 /**
  * Newspack dependencies.
  */
-import {
-	Button,
-	Card,
-	FormattedHeader,
-	Grid,
-	NewspackLogo,
-	Notice,
-	TextControl,
-} from 'newspack-components';
-
-/**
- * Material UI dependencies.
- */
-import UnarchiveIcon from '@material-ui/icons/Unarchive';
+import { NewspackLogo } from 'newspack-components';
 
 /**
  * Internal dependencies.
@@ -114,82 +111,107 @@ class Conversion extends Component {
 		if ( '1' == isConversionOngoing ) {
 			return (
 				<Fragment>
-					<div className="newspack-logo-wrapper">
-						<NewspackLogo />
-					</div>
-					<Grid>
-						<FormattedHeader
-							headerIcon={ <UnarchiveIcon /> }
-							headerText={ __( 'Run conversion' ) }
-							subHeaderText={ __( 'Start conversion to Gutenberg blocks.' ) }
-						/>
-						<Card>
-							<Notice
-								noticeText={ __(
-									'A designated browser tab has already started to convert your content.'
-								) }
-								isPrimary
-							/>
-							<hr />
-							<h2>{ __( 'Reset ongoing conversion' ) }</h2>
+					<Card>
+						<CardHeader isShady>
+							<FlexBlock>
+								<h2>{ __( 'Converting...' ) }</h2>
+								<p>{ __( 'The conversion is already running' ) }</p>
+							</FlexBlock>
+						</CardHeader>
+						<CardFooter isBorderless>
 							<p>
-								{ __(
-									'In case that your active conversion browser tab has been closed by accident, or it has been interrupted and closed unexpectedly, you may reset the conversion status here, and start converting all over again.'
-								) }
+								{ __( 'A designated browser tab has already started to convert your content.' ) }
 							</p>
-							<Notice
-								noticeText={ __(
+						</CardFooter>
+					</Card>
+					<Card>
+						<CardHeader isShady>
+							<FlexBlock>
+								<h2>{ __( 'Reset Conversion' ) }</h2>
+								<p>{ __( 'Start converting all over again' ) }</p>
+							</FlexBlock>
+						</CardHeader>
+						<CardBody>
+							<Notice status="warning" isDismissible={ false }>
+								{ __(
 									'This will enable you to restart the conversion, but any previous results may be lost.'
 								) }
-								isWarning
-							/>
-							<div className="newspack-buttons-card">
-								<Button isPrimary onClick={ this.handleOnClickResetConversion }>
-									{ __( 'Reset conversion' ) }
-								</Button>
-							</div>
-						</Card>
-					</Grid>
+							</Notice>
+							<p>
+								{ __(
+									'In case that your active conversion browser tab has been closed by accident, or it has been interrupted and closed unexpectedly, you may reset the conversion status here.'
+								) }
+							</p>
+						</CardBody>
+						<CardFooter justify="flex-end">
+							<Button isPrimary onClick={ this.handleOnClickResetConversion }>
+								{ __( 'Reset Conversion' ) }
+							</Button>
+						</CardFooter>
+					</Card>
+					<div className="newspack-logo__wrapper">
+						<Button
+							href="https://newspack.pub/"
+							target="_blank"
+							label={ __( 'By Newspack' ) }
+						>
+							<NewspackLogo />
+						</Button>
+					</div>
 				</Fragment>
 			);
 		} else {
 			return (
 				<Fragment>
-					<div className="newspack-logo-wrapper">
-						<NewspackLogo />
-					</div>
-					<Grid>
-						<FormattedHeader
-							headerIcon={ <UnarchiveIcon /> }
-							headerText={ __( 'Run conversion' ) }
-							subHeaderText={ __( 'Start conversion to Gutenberg blocks.' ) }
-						/>
+					{ !! someConversionsFailed && (
 						<Card>
-							{ !! someConversionsFailed && (
-								<Fragment>
-									<Notice
-										noticeText={ __(
-											"Looks like some entries weren't converted properly. You may retry converting these."
+							<CardHeader isShady>
+								<FlexBlock>
+									<h2>{ __( 'Conversion Error' ) }</h2>
+									<p>
+										{ __( 'Retry converting the failed entries' ) }
+									</p>
+								</FlexBlock>
+							</CardHeader>
+							<CardBody>
+								<FlexBlock>
+									<Notice status="error" isDismissible={ false }>
+										{ __(
+											"Looks like some entries weren't converted properly."
 										) }
-										isError
-									/>
+									</Notice>
 									<TextControl
 										label={ __( 'Number of failed entries' ) }
 										disabled={ true }
 										value={ countFailedConverting }
 									/>
-									<Card noBackground className="newspack-card__buttons-card">
-										<Button isPrimary onClick={ this.handleOnClickInitializeRetryFailed }>
-											{ __( 'Retry conversion' ) }
-										</Button>
-									</Card>
-									<hr />
-								</Fragment>
-							) }
-							<Notice
-								noticeText={ __( 'This page will automatically reload for every batch.' ) }
-								isPrimary
-							/>
+								</FlexBlock>
+							</CardBody>
+							<CardFooter justify="flex-end">
+								<Button isPrimary onClick={ this.handleOnClickInitializeRetryFailed }>
+									{ __( 'Retry Conversion' ) }
+								</Button>
+							</CardFooter>
+						</Card>
+					) }
+					<Card>
+						<CardHeader isShady>
+							<FlexBlock>
+								<h2>{ __( 'Run Conversion' ) }</h2>
+								<p>
+									{ __( 'Start conversion to Gutenberg blocks' ) }
+								</p>
+							</FlexBlock>
+						</CardHeader>
+						<CardBody>
+							<Notice status="warning" isDismissible={ false }>
+								{ __(
+									'Once started, the conversion should not be interrupted! Your browser page needs to remain active until conversion is complete.'
+								) }
+							</Notice>
+							<h4>
+								{ __( 'This page will automatically reload for every batch.' ) }
+							</h4>
 							<TextControl
 								label={ __( 'Number of entries to be converted' ) }
 								disabled={ true }
@@ -200,25 +222,28 @@ class Conversion extends Component {
 								disabled={ true }
 								value={ maxBatch }
 							/>
-							<Notice
-								noticeText={ __(
-									'Once started, the conversion should not be interrupted! Your browser page needs to remain active until conversion is complete.'
-								) }
-								isWarning
-							/>
-							<div className="newspack-buttons-card">
-								<Button isPrimary onClick={ this.handleOnClickInitializeConversion }>
-									{ __( 'Run conversion' ) }
-								</Button>
-								<Button
-									isSecondary
-									href="/wp-admin/admin.php?page=newspack-content-converter-settings"
-								>
-									{ __( 'Settings' ) }
-								</Button>
-							</div>
-						</Card>
-					</Grid>
+						</CardBody>
+						<CardFooter justify="flex-end">
+							<Button
+								isSecondary
+								href="/wp-admin/admin.php?page=newspack-content-converter-settings"
+							>
+								{ __( 'Settings' ) }
+							</Button>
+							<Button isPrimary onClick={ this.handleOnClickInitializeConversion }>
+								{ __( 'Run Conversion' ) }
+							</Button>
+						</CardFooter>
+					</Card>
+					<div className="newspack-logo__wrapper">
+						<Button
+							href="https://newspack.pub/"
+							target="_blank"
+							label={ __( 'By Newspack' ) }
+						>
+							<NewspackLogo />
+						</Button>
+					</div>
 				</Fragment>
 			);
 		}

--- a/assets/src/index.js
+++ b/assets/src/index.js
@@ -27,6 +27,16 @@ const nccInsertRootAdjacentToElementByClass = function( className ) {
 	nccGetElementByClassName( className ).insertAdjacentHTML( 'afterend', '<div id="root"></div>' );
 };
 
+const nccRenderRoot = function() {
+	window.onbeforeunload = function() {};
+
+	const getParams = queryString.parse( window.location.search );
+	render(
+		<ContentConverter retryFailedConversions={ 'retry-failed' in getParams } />,
+		document.getElementById( 'root' )
+	);
+};
+
 // Wrapper function which enables retrying a callback after a timeout interval and for a defined maxAttempts (useful to retry
 // actions for elements which haven't yet been injected into DOM).
 function nccCallbackWithRetry( callback, callbackParam, maxAttempts = 10, timeout = 1000 ) {
@@ -64,13 +74,6 @@ window.onload = function() {
 		nccCallbackWithRetry( nccHideElementByClass, 'edit-post-layout__content' );
 		nccCallbackWithRetry( nccHideElementByClass, 'edit-post-sidebar' );
 		nccCallbackWithRetry( nccInsertRootAdjacentToElementByClass, 'edit-post-header' );
-
-		window.onbeforeunload = function() {};
-
-		const getParams = queryString.parse( window.location.search );
-		render(
-			<ContentConverter retryFailedConversions={ 'retry-failed' in getParams } />,
-			document.getElementById( 'root' )
-		);
+		nccCallbackWithRetry( nccRenderRoot );
 	}
 };

--- a/assets/src/settings/index.js
+++ b/assets/src/settings/index.js
@@ -57,6 +57,15 @@ class Settings extends Component {
 
 		return (
 			<Fragment>
+				<div className="newspack-logo__wrapper">
+					<Button
+						href="https://newspack.pub/"
+						target="_blank"
+						label={ __( 'By Newspack' ) }
+					>
+						<NewspackLogo />
+					</Button>
+				</div>
 				<Card>
 					<CardHeader isShady>
 						<FlexBlock>
@@ -92,15 +101,6 @@ class Settings extends Component {
 						</Button>
 					</CardFooter>
 				</Card>
-				<div className="newspack-logo__wrapper">
-					<Button
-						href="https://newspack.pub/"
-						target="_blank"
-						label={ __( 'By Newspack' ) }
-					>
-						<NewspackLogo />
-					</Button>
-				</div>
 			</Fragment>
 		);
 	}

--- a/assets/src/settings/index.js
+++ b/assets/src/settings/index.js
@@ -3,23 +3,20 @@
  */
 import { Component, Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import {
+	Button,
+	Card,
+	CardBody,
+	CardFooter,
+	CardHeader,
+	FlexBlock,
+	TextControl
+} from '@wordpress/components';
 
 /**
  * Newspack dependencies.
  */
-import {
-	Button,
-	Card,
-	FormattedHeader,
-	Grid,
-	NewspackLogo,
-	TextControl,
-} from 'newspack-components';
-
-/**
- * Material UI dependencies.
- */
-import SettingsIcon from '@material-ui/icons/Settings';
+import { NewspackLogo } from 'newspack-components';
 
 /**
  * Internal dependencies.
@@ -60,16 +57,16 @@ class Settings extends Component {
 
 		return (
 			<Fragment>
-				<div className="newspack-logo-wrapper">
-					<NewspackLogo />
-				</div>
-				<Grid>
-					<FormattedHeader
-						headerIcon={ <SettingsIcon /> }
-						headerText={ __( 'Settings' ) }
-						subHeaderText={ __( 'Adding content to the queue to convert it to Gutenberg blocks.' ) }
-					/>
-					<Card>
+				<Card>
+					<CardHeader isShady>
+						<FlexBlock>
+							<h2>{ __( 'Settings' ) }</h2>
+							<p>
+								{ __( 'Adding content to the queue to convert it to Gutenberg blocks' ) }
+							</p>
+						</FlexBlock>
+					</CardHeader>
+					<CardBody>
 						<p>
 							{ __(
 								'The type of HTML content to be converted to Gutenberg blocks is specified here.'
@@ -85,13 +82,25 @@ class Settings extends Component {
 							disabled={ true }
 							value={ conversionContentStatusesCsv }
 						/>
-						<div className="newspack-buttons-card">
-							<Button isPrimary href="/wp-admin/admin.php?page=newspack-content-converter">
-								{ __( 'Run conversion' ) }
-							</Button>
-						</div>
-					</Card>
-				</Grid>
+					</CardBody>
+					<CardFooter justify="flex-end">
+						<Button
+							isPrimary
+							href="/wp-admin/admin.php?page=newspack-content-converter"
+						>
+							{ __( 'Run Conversion' ) }
+						</Button>
+					</CardFooter>
+				</Card>
+				<div className="newspack-logo__wrapper">
+					<Button
+						href="https://newspack.pub/"
+						target="_blank"
+						label={ __( 'By Newspack' ) }
+					>
+						<NewspackLogo />
+					</Button>
+				</div>
 			</Fragment>
 		);
 	}

--- a/assets/src/style.scss
+++ b/assets/src/style.scss
@@ -1,145 +1,79 @@
-@import '~newspack-components/shared/scss/colors';
+@import '~@wordpress/base-styles/colors';
 
-.toplevel_page_newspack-content-converter,
-body[class*="newspack-content-converter_"] {
-	#wpcontent {
-		padding-left: 0;
-	}
+.components-card {
+	margin: 2rem auto;
+	max-width: 520px;
 
- 	#wpfooter {
-		&:before {
-			background-image: url("data:image/svg+xml,%3Csvg width='32' height='32' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M32 16c0 8.836-7.164 16-16 16-8.837 0-16-7.164-16-16S7.164 0 16 0s16 7.164 16 16zm-10.732.623h1.72v-1.125h-2.823l1.103 1.125zm-3.249-3.31h4.97v-1.125h-6.072l1.102 1.124v.001zm-3.248-3.311h8.217V8.878h-9.32l1.103 1.124zM9.01 8.878l13.977 14.245h-4.66l-5.866-5.98v5.98h-3.45V8.878H9.01z' fill='%23d7dade' fill-rule='evenodd'/%3E%3C/svg%3E%0A");
-			background-size: 24px 24px;
-			bottom: 10px;
-			content: "";
-			display: block;
-			height: 24px;
-			left: 50%;
-			margin: 0;
-			margin-left: -12px;
-			position: absolute;
-			width: 24px;
+	&__header {
+		h2 {
+			margin-bottom: 0;
+		}
+
+		p {
+			margin-top: 0;
 		}
 	}
 
-	.newspack-card.newspack-card__buttons-card {
-		& + hr {
-			margin-top: 56px;
-		}
+	.components-notice {
+		margin: 1em 0;
 	}
 }
 
-// Editable Card
-.newspack-card__editable {
-	align-items: flex-end;
+.newspack-logo__wrapper {
 	display: flex;
+	justify-content: center;
 
-	> * {
-		flex: 1;
-		margin: 0;
+	.components-button {
+		color: $gray-400;
+		height: 32px;
+		padding: 0;
+
+		&:hover {
+			color: $gray-900;
+		}
 	}
 
-	.newspack-button__edit {
-		color: inherit;
-		flex: 0 0 48px;
-		height: 48px;
-		justify-content: center;
-		margin-left: 8px;
+	.newspack-logo {
+		display: block;
+		fill: currentColor;
+		height: inherit;
 		padding: 0;
 	}
 }
 
-// Wrapper
-.newspack-content-converter__wrapper {
-	bottom: 0;
-	display: flex;
-	flex-direction: column;
-	left: 0;
-	overflow-y: auto;
-	position: absolute;
-	right: 0;
-	top: 0;
-	z-index: 9999;
-
-	&:before {
-		background: $primary-500;
+.newspack-content-converter {
+	&__wrapper {
+		background: #f1f1f1;
 		bottom: 0;
-		content: "";
 		display: block;
+		flex-direction: column;
 		left: 0;
-		min-height: 100vh;
+		overflow-y: auto;
 		position: fixed;
 		right: 0;
 		top: 0;
-		z-index: -1;
-	}
+		z-index: 9999;
 
-	.newspack-logo-wrapper {
-		margin-bottom: 32px;
-	}
+		&.is-active {
+			cursor: wait;
+		}
 
-	.newspack-grid {
-		flex: 1 1 100%;
-		padding-bottom: 32px;
-		width: 100%;
-	}
+		.components-spinner {
+			margin: 1em 0;
+		}
 
-	&.newspack-content-converter__is-active {
-		cursor: wait;
-
-		.newspack-card {
-			position: relative;
-
-			&:before {
-				animation: newspack-content-converter__is-active-animation 2s ease-in-out infinite;
-				background: $primary-800;
-				content: "";
-				display: block;
-				height: 4px;
-				left: 0;
-				position: absolute;
-				right: 100%;
-				top: 0;
-				z-index: 1;
-			}
+		.components-button + .components-button {
+			margin-left: 8px;
 		}
 	}
 
-	> * {
-		position: relative;
-	}
-
-	.newspack-formatted-header {
-		.newspack-formatted-header__title,
-		.newspack-formatted-header__subtitle {
-			color: white;
-		}
-
-		.newspack-formatted-header__icon svg {
-			fill: white;
+	&__batch {
+		.components-spinner {
+			margin: 0 1em 0 0;
 		}
 	}
 }
 
-// Status
-.newspack-content-converter__status {
-	align-items: center;
-	display: flex;
-}
-
-@keyframes newspack-content-converter__is-active-animation {
-	from {
-		left: 0;
-		right: 100%;
-	}
-
-	50% {
-		left: 0;
-		right: 0;
-	}
-
-	to {
-		left: 100%;
-		right: 0;
-	}
+.interface-interface-skeleton__footer {
+	display: none;
 }

--- a/assets/src/style.scss
+++ b/assets/src/style.scss
@@ -1,4 +1,4 @@
-@import '~@wordpress/base-styles/colors';
+@import '~newspack-components/shared/scss/colors';
 
 .components-card {
 	margin: 2rem auto;
@@ -19,25 +19,51 @@
 	}
 }
 
-.newspack-logo__wrapper {
-	display: flex;
-	justify-content: center;
+.newspack-logo {
+	display: block;
+	fill: currentColor;
+	height: inherit;
+	padding: 0;
 
-	.components-button {
-		color: $gray-400;
-		height: 32px;
-		padding: 0;
+	&__wrapper {
+		background: $primary-500;
+		display: flex;
+		padding: 12px 0;
+		position: relative;
 
-		&:hover {
-			color: $gray-900;
+		&::before {
+			background: $primary-500;
+			bottom: 0;
+			content: '';
+			display: block;
+			left: -20px;
+			position: absolute;
+			right: 0;
+			top: 0;
+			z-index: -1;
 		}
-	}
 
-	.newspack-logo {
-		display: block;
-		fill: currentColor;
-		height: inherit;
-		padding: 0;
+		.components-button {
+			color: white;
+			display: block;
+			height: 32px;
+			padding: 0;
+			width: 100%;
+
+			&:focus,
+			&:hover {
+				box-shadow: none;
+				color: white;
+				outline: none;
+			}
+
+			&:focus {
+				svg {
+					outline: 1px solid white;
+					outline-offset: 4px;
+				}
+			}
+		}
 	}
 }
 
@@ -65,6 +91,10 @@
 		.components-button + .components-button {
 			margin-left: 8px;
 		}
+
+		.newspack-logo {
+			margin: 0 20px;
+		}
 	}
 
 	&__batch {
@@ -74,6 +104,12 @@
 	}
 }
 
-.interface-interface-skeleton__footer {
-	display: none;
+.interface-interface-skeleton {
+	&__body {
+		opacity: 0;
+	}
+
+	&__footer {
+		display: none;
+	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -617,50 +617,241 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
       "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
-      "dev": true,
       "requires": {
         "@babel/highlight": "^7.0.0"
       }
     },
     "@babel/core": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.5.4.tgz",
-      "integrity": "sha512-+DaeBEpYq6b2+ZmHx3tHspC+ZRflrvLqwfv8E3hNr5LVQoyBnL8RPKSBCg+rK2W2My9PWlujBiqd0ZPsR9Q6zQ==",
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.12.13.tgz",
+      "integrity": "sha512-BQKE9kXkPlXHPeqissfxo0lySWJcYdEP0hdtJOH/iJfDdhOCcgtNCjftCJg3qqauB4h+lz2N6ixM++b9DN1Tcw==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/generator": "^7.5.0",
-        "@babel/helpers": "^7.5.4",
-        "@babel/parser": "^7.5.0",
-        "@babel/template": "^7.4.4",
-        "@babel/traverse": "^7.5.0",
-        "@babel/types": "^7.5.0",
-        "convert-source-map": "^1.1.0",
+        "@babel/code-frame": "^7.12.13",
+        "@babel/generator": "^7.12.13",
+        "@babel/helper-module-transforms": "^7.12.13",
+        "@babel/helpers": "^7.12.13",
+        "@babel/parser": "^7.12.13",
+        "@babel/template": "^7.12.13",
+        "@babel/traverse": "^7.12.13",
+        "@babel/types": "^7.12.13",
+        "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
-        "json5": "^2.1.0",
-        "lodash": "^4.17.11",
-        "resolve": "^1.3.2",
+        "gensync": "^1.0.0-beta.1",
+        "json5": "^2.1.2",
+        "lodash": "^4.17.19",
         "semver": "^5.4.1",
         "source-map": "^0.5.0"
       },
       "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+        "@babel/code-frame": {
+          "version": "7.12.13",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
+          "integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "@babel/highlight": "^7.12.13"
+          }
+        },
+        "@babel/generator": {
+          "version": "7.12.15",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.15.tgz",
+          "integrity": "sha512-6F2xHxBiFXWNSGb7vyCUTBF8RCLY66rS0zEPcP8t/nQyXjha5EuK4z7H5o7fWG8B4M7y6mqVWq1J+1PuwRhecQ==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.12.13",
+            "jsesc": "^2.5.1",
+            "source-map": "^0.5.0"
+          }
+        },
+        "@babel/helper-function-name": {
+          "version": "7.12.13",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.13.tgz",
+          "integrity": "sha512-TZvmPn0UOqmvi5G4vvw0qZTpVptGkB1GL61R6lKvrSdIxGm5Pky7Q3fpKiIkQCAtRCBUwB0PaThlx9vebCDSwA==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-get-function-arity": "^7.12.13",
+            "@babel/template": "^7.12.13",
+            "@babel/types": "^7.12.13"
+          }
+        },
+        "@babel/helper-get-function-arity": {
+          "version": "7.12.13",
+          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.13.tgz",
+          "integrity": "sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.12.13"
+          }
+        },
+        "@babel/helper-member-expression-to-functions": {
+          "version": "7.12.13",
+          "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.13.tgz",
+          "integrity": "sha512-B+7nN0gIL8FZ8SvMcF+EPyB21KnCcZHQZFczCxbiNGV/O0rsrSBlWGLzmtBJ3GMjSVMIm4lpFhR+VdVBuIsUcQ==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.12.13"
+          }
+        },
+        "@babel/helper-module-imports": {
+          "version": "7.12.13",
+          "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.12.13.tgz",
+          "integrity": "sha512-NGmfvRp9Rqxy0uHSSVP+SRIW1q31a7Ji10cLBcqSDUngGentY4FRiHOFZFE1CLU5eiL0oE8reH7Tg1y99TDM/g==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.12.13"
+          }
+        },
+        "@babel/helper-module-transforms": {
+          "version": "7.12.13",
+          "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.12.13.tgz",
+          "integrity": "sha512-acKF7EjqOR67ASIlDTupwkKM1eUisNAjaSduo5Cz+793ikfnpe7p4Q7B7EWU2PCoSTPWsQkR7hRUWEIZPiVLGA==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-module-imports": "^7.12.13",
+            "@babel/helper-replace-supers": "^7.12.13",
+            "@babel/helper-simple-access": "^7.12.13",
+            "@babel/helper-split-export-declaration": "^7.12.13",
+            "@babel/helper-validator-identifier": "^7.12.11",
+            "@babel/template": "^7.12.13",
+            "@babel/traverse": "^7.12.13",
+            "@babel/types": "^7.12.13",
+            "lodash": "^4.17.19"
+          }
+        },
+        "@babel/helper-optimise-call-expression": {
+          "version": "7.12.13",
+          "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.13.tgz",
+          "integrity": "sha512-BdWQhoVJkp6nVjB7nkFWcn43dkprYauqtk++Py2eaf/GRDFm5BxRqEIZCiHlZUGAVmtwKcsVL1dC68WmzeFmiA==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.12.13"
+          }
+        },
+        "@babel/helper-replace-supers": {
+          "version": "7.12.13",
+          "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.12.13.tgz",
+          "integrity": "sha512-pctAOIAMVStI2TMLhozPKbf5yTEXc0OJa0eENheb4w09SrgOWEs+P4nTOZYJQCqs8JlErGLDPDJTiGIp3ygbLg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-member-expression-to-functions": "^7.12.13",
+            "@babel/helper-optimise-call-expression": "^7.12.13",
+            "@babel/traverse": "^7.12.13",
+            "@babel/types": "^7.12.13"
+          }
+        },
+        "@babel/helper-simple-access": {
+          "version": "7.12.13",
+          "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.12.13.tgz",
+          "integrity": "sha512-0ski5dyYIHEfwpWGx5GPWhH35j342JaflmCeQmsPWcrOQDtCN6C1zKAVRFVbK53lPW2c9TsuLLSUDf0tIGJ5hA==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.12.13"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.12.13",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz",
+          "integrity": "sha512-tCJDltF83htUtXx5NLcaDqRmknv652ZWCHyoTETf1CXYJdPC7nohZohjUgieXhv0hTJdRf2FjDueFehdNucpzg==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.12.13"
+          }
+        },
+        "@babel/highlight": {
+          "version": "7.12.13",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.12.13.tgz",
+          "integrity": "sha512-kocDQvIbgMKlWxXe9fof3TQ+gkIPOUSEYhJjqUjvKMez3krV7vbzYCDq39Oj11UAVK7JqPVGQPlgE85dPNlQww==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.12.11",
+            "chalk": "^2.0.0",
+            "js-tokens": "^4.0.0"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.12.15",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.15.tgz",
+          "integrity": "sha512-AQBOU2Z9kWwSZMd6lNjCX0GUgFonL1wAM1db8L8PMk9UDaGsRCArBkU4Sc+UCM3AE4hjbXx+h58Lb3QT4oRmrA==",
+          "dev": true
+        },
+        "@babel/template": {
+          "version": "7.12.13",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
+          "integrity": "sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.12.13",
+            "@babel/parser": "^7.12.13",
+            "@babel/types": "^7.12.13"
+          }
+        },
+        "@babel/traverse": {
+          "version": "7.12.13",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.13.tgz",
+          "integrity": "sha512-3Zb4w7eE/OslI0fTp8c7b286/cQps3+vdLW3UcwC8VSJC6GbKn55aeVVu2QJNuCDoeKyptLOFrPq8WqZZBodyA==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.12.13",
+            "@babel/generator": "^7.12.13",
+            "@babel/helper-function-name": "^7.12.13",
+            "@babel/helper-split-export-declaration": "^7.12.13",
+            "@babel/parser": "^7.12.13",
+            "@babel/types": "^7.12.13",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0",
+            "lodash": "^4.17.19"
+          }
+        },
+        "@babel/types": {
+          "version": "7.12.13",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.13.tgz",
+          "integrity": "sha512-oKrdZTld2im1z8bDwTOQvUbxKwE+854zc16qWZQlcTqMN00pWxHQ4ZeOq0yDMnisOpRykH2/5Qqcrk/OlbAjiQ==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.12.11",
+            "lodash": "^4.17.19",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "convert-source-map": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
+          "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.1"
+          }
+        },
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
           }
         },
         "json5": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
-          "integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
+          "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
           "dev": true,
           "requires": {
-            "minimist": "^1.2.0"
+            "minimist": "^1.2.5"
           }
+        },
+        "lodash": {
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
+        },
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "dev": true
         },
         "ms": {
           "version": "2.1.2",
@@ -1270,7 +1461,6 @@
       "version": "7.8.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.8.0.tgz",
       "integrity": "sha512-ylY9J6ZxEcjmJaJ4P6aVs/fZdrZVctCGnxxfYXwCnSMapqd544zT8lWK2qI/vBPjE5gS0o2jILnH+AkpsPauEQ==",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.8.0"
       },
@@ -1279,7 +1469,6 @@
           "version": "7.8.0",
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.0.tgz",
           "integrity": "sha512-1RF84ehyx9HH09dMMwGWl3UTWlVoCPtqqJPjGuC4JzMe1ZIVDJ2DT8mv3cPv/A7veLD6sgR7vi95lJqm+ZayIg==",
-          "dev": true,
           "requires": {
             "esutils": "^2.0.2",
             "lodash": "^4.17.13",
@@ -1738,6 +1927,12 @@
         "@babel/types": "^7.4.4"
       }
     },
+    "@babel/helper-validator-identifier": {
+      "version": "7.12.11",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+      "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
+      "dev": true
+    },
     "@babel/helper-wrap-function": {
       "version": "7.8.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.8.0.tgz",
@@ -1874,21 +2069,148 @@
       }
     },
     "@babel/helpers": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.5.4.tgz",
-      "integrity": "sha512-6LJ6xwUEJP51w0sIgKyfvFMJvIb9mWAfohJp0+m6eHJigkFdcH8duZ1sfhn0ltJRzwUIT/yqqhdSfRpCpL7oow==",
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.12.13.tgz",
+      "integrity": "sha512-oohVzLRZ3GQEk4Cjhfs9YkJA4TdIDTObdBEZGrd6F/T0GPSnuV6l22eMcxlvcvzVIPH3VTtxbseudM1zIE+rPQ==",
       "dev": true,
       "requires": {
-        "@babel/template": "^7.4.4",
-        "@babel/traverse": "^7.5.0",
-        "@babel/types": "^7.5.0"
+        "@babel/template": "^7.12.13",
+        "@babel/traverse": "^7.12.13",
+        "@babel/types": "^7.12.13"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.12.13",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
+          "integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "^7.12.13"
+          }
+        },
+        "@babel/generator": {
+          "version": "7.12.15",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.15.tgz",
+          "integrity": "sha512-6F2xHxBiFXWNSGb7vyCUTBF8RCLY66rS0zEPcP8t/nQyXjha5EuK4z7H5o7fWG8B4M7y6mqVWq1J+1PuwRhecQ==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.12.13",
+            "jsesc": "^2.5.1",
+            "source-map": "^0.5.0"
+          }
+        },
+        "@babel/helper-function-name": {
+          "version": "7.12.13",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.13.tgz",
+          "integrity": "sha512-TZvmPn0UOqmvi5G4vvw0qZTpVptGkB1GL61R6lKvrSdIxGm5Pky7Q3fpKiIkQCAtRCBUwB0PaThlx9vebCDSwA==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-get-function-arity": "^7.12.13",
+            "@babel/template": "^7.12.13",
+            "@babel/types": "^7.12.13"
+          }
+        },
+        "@babel/helper-get-function-arity": {
+          "version": "7.12.13",
+          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.13.tgz",
+          "integrity": "sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.12.13"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.12.13",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz",
+          "integrity": "sha512-tCJDltF83htUtXx5NLcaDqRmknv652ZWCHyoTETf1CXYJdPC7nohZohjUgieXhv0hTJdRf2FjDueFehdNucpzg==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.12.13"
+          }
+        },
+        "@babel/highlight": {
+          "version": "7.12.13",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.12.13.tgz",
+          "integrity": "sha512-kocDQvIbgMKlWxXe9fof3TQ+gkIPOUSEYhJjqUjvKMez3krV7vbzYCDq39Oj11UAVK7JqPVGQPlgE85dPNlQww==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.12.11",
+            "chalk": "^2.0.0",
+            "js-tokens": "^4.0.0"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.12.15",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.15.tgz",
+          "integrity": "sha512-AQBOU2Z9kWwSZMd6lNjCX0GUgFonL1wAM1db8L8PMk9UDaGsRCArBkU4Sc+UCM3AE4hjbXx+h58Lb3QT4oRmrA==",
+          "dev": true
+        },
+        "@babel/template": {
+          "version": "7.12.13",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
+          "integrity": "sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.12.13",
+            "@babel/parser": "^7.12.13",
+            "@babel/types": "^7.12.13"
+          }
+        },
+        "@babel/traverse": {
+          "version": "7.12.13",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.13.tgz",
+          "integrity": "sha512-3Zb4w7eE/OslI0fTp8c7b286/cQps3+vdLW3UcwC8VSJC6GbKn55aeVVu2QJNuCDoeKyptLOFrPq8WqZZBodyA==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.12.13",
+            "@babel/generator": "^7.12.13",
+            "@babel/helper-function-name": "^7.12.13",
+            "@babel/helper-split-export-declaration": "^7.12.13",
+            "@babel/parser": "^7.12.13",
+            "@babel/types": "^7.12.13",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0",
+            "lodash": "^4.17.19"
+          }
+        },
+        "@babel/types": {
+          "version": "7.12.13",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.13.tgz",
+          "integrity": "sha512-oKrdZTld2im1z8bDwTOQvUbxKwE+854zc16qWZQlcTqMN00pWxHQ4ZeOq0yDMnisOpRykH2/5Qqcrk/OlbAjiQ==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.12.11",
+            "lodash": "^4.17.19",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "lodash": {
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
       }
     },
     "@babel/highlight": {
       "version": "7.5.0",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.5.0.tgz",
       "integrity": "sha512-7dV4eu9gBxoM0dAnj/BCFDW9LFU0zvTrkq0ugM7pnHEgguOEeOz1so2ZghEdzviYzQEED0r4EAgpsBChKy1TRQ==",
-      "dev": true,
       "requires": {
         "chalk": "^2.0.0",
         "esutils": "^2.0.2",
@@ -2730,11 +3052,11 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.4.tgz",
-      "integrity": "sha512-Na84uwyImZZc3FKf4aUF1tysApzwf3p2yuFBIyBfbzT5glzKTdvYI4KVW4kcgjrzoGUjC7w3YyCHcJKaRxsr2Q==",
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.13.tgz",
+      "integrity": "sha512-8+3UMPBrjFa/6TtKi/7sehPKqfAm4g6K+YQjyyFOLUTxzOngcRZTlAVY8sc2CORJYqdHQY8gRPHmn+qo15rCBw==",
       "requires": {
-        "regenerator-runtime": "^0.13.2"
+        "regenerator-runtime": "^0.13.4"
       }
     },
     "@babel/template": {
@@ -2803,10 +3125,142 @@
         "minimist": "^1.2.0"
       }
     },
+    "@emotion/cache": {
+      "version": "10.0.29",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-10.0.29.tgz",
+      "integrity": "sha512-fU2VtSVlHiF27empSbxi1O2JFdNWZO+2NFHfwO0pxgTep6Xa3uGb+3pVKfLww2l/IBGLNEZl5Xf/++A4wAYDYQ==",
+      "requires": {
+        "@emotion/sheet": "0.9.4",
+        "@emotion/stylis": "0.8.5",
+        "@emotion/utils": "0.11.3",
+        "@emotion/weak-memoize": "0.2.5"
+      }
+    },
+    "@emotion/core": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/@emotion/core/-/core-10.1.1.tgz",
+      "integrity": "sha512-ZMLG6qpXR8x031NXD8HJqugy/AZSkAuMxxqB46pmAR7ze47MhNJ56cdoX243QPZdGctrdfo+s08yZTiwaUcRKA==",
+      "requires": {
+        "@babel/runtime": "^7.5.5",
+        "@emotion/cache": "^10.0.27",
+        "@emotion/css": "^10.0.27",
+        "@emotion/serialize": "^0.11.15",
+        "@emotion/sheet": "0.9.4",
+        "@emotion/utils": "0.11.3"
+      }
+    },
+    "@emotion/css": {
+      "version": "10.0.27",
+      "resolved": "https://registry.npmjs.org/@emotion/css/-/css-10.0.27.tgz",
+      "integrity": "sha512-6wZjsvYeBhyZQYNrGoR5yPMYbMBNEnanDrqmsqS1mzDm1cOTu12shvl2j4QHNS36UaTE0USIJawCH9C8oW34Zw==",
+      "requires": {
+        "@emotion/serialize": "^0.11.15",
+        "@emotion/utils": "0.11.3",
+        "babel-plugin-emotion": "^10.0.27"
+      }
+    },
     "@emotion/hash": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
+      "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
+    },
+    "@emotion/is-prop-valid": {
+      "version": "0.8.8",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
+      "integrity": "sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==",
+      "requires": {
+        "@emotion/memoize": "0.7.4"
+      }
+    },
+    "@emotion/memoize": {
       "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.7.4.tgz",
-      "integrity": "sha512-fxfMSBMX3tlIbKUdtGKxqB1fyrH6gVrX39Gsv3y8lRYKUqlgDt3UMqQyGnR1bQMa2B8aGnhLZokZgg8vT0Le+A=="
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
+      "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw=="
+    },
+    "@emotion/native": {
+      "version": "10.0.27",
+      "resolved": "https://registry.npmjs.org/@emotion/native/-/native-10.0.27.tgz",
+      "integrity": "sha512-3qxR2XFizGfABKKbX9kAYc0PHhKuCEuyxshoq3TaMEbi9asWHdQVChg32ULpblm4XAf9oxaitAU7J9SfdwFxtw==",
+      "requires": {
+        "@emotion/primitives-core": "10.0.27"
+      }
+    },
+    "@emotion/primitives-core": {
+      "version": "10.0.27",
+      "resolved": "https://registry.npmjs.org/@emotion/primitives-core/-/primitives-core-10.0.27.tgz",
+      "integrity": "sha512-fRBEDNPSFFOrBJ0OcheuElayrNTNdLF9DzMxtL0sFgsCFvvadlzwJHhJMSwEJuxwARm9GhVLr1p8G8JGkK98lQ==",
+      "requires": {
+        "css-to-react-native": "^2.2.1"
+      }
+    },
+    "@emotion/serialize": {
+      "version": "0.11.16",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-0.11.16.tgz",
+      "integrity": "sha512-G3J4o8by0VRrO+PFeSc3js2myYNOXVJ3Ya+RGVxnshRYgsvErfAOglKAiy1Eo1vhzxqtUvjCyS5gtewzkmvSSg==",
+      "requires": {
+        "@emotion/hash": "0.8.0",
+        "@emotion/memoize": "0.7.4",
+        "@emotion/unitless": "0.7.5",
+        "@emotion/utils": "0.11.3",
+        "csstype": "^2.5.7"
+      },
+      "dependencies": {
+        "csstype": {
+          "version": "2.6.14",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.14.tgz",
+          "integrity": "sha512-2mSc+VEpGPblzAxyeR+vZhJKgYg0Og0nnRi7pmRXFYYxSfnOnW8A5wwQb4n4cE2nIOzqKOAzLCaEX6aBmNEv8A=="
+        }
+      }
+    },
+    "@emotion/sheet": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-0.9.4.tgz",
+      "integrity": "sha512-zM9PFmgVSqBw4zL101Q0HrBVTGmpAxFZH/pYx/cjJT5advXguvcgjHFTCaIO3enL/xr89vK2bh0Mfyj9aa0ANA=="
+    },
+    "@emotion/styled": {
+      "version": "10.0.27",
+      "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-10.0.27.tgz",
+      "integrity": "sha512-iK/8Sh7+NLJzyp9a5+vIQIXTYxfT4yB/OJbjzQanB2RZpvmzBQOHZWhpAMZWYEKRNNbsD6WfBw5sVWkb6WzS/Q==",
+      "requires": {
+        "@emotion/styled-base": "^10.0.27",
+        "babel-plugin-emotion": "^10.0.27"
+      }
+    },
+    "@emotion/styled-base": {
+      "version": "10.0.31",
+      "resolved": "https://registry.npmjs.org/@emotion/styled-base/-/styled-base-10.0.31.tgz",
+      "integrity": "sha512-wTOE1NcXmqMWlyrtwdkqg87Mu6Rj1MaukEoEmEkHirO5IoHDJ8LgCQL4MjJODgxWxXibGR3opGp1p7YvkNEdXQ==",
+      "requires": {
+        "@babel/runtime": "^7.5.5",
+        "@emotion/is-prop-valid": "0.8.8",
+        "@emotion/serialize": "^0.11.15",
+        "@emotion/utils": "0.11.3"
+      }
+    },
+    "@emotion/stylis": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.8.5.tgz",
+      "integrity": "sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ=="
+    },
+    "@emotion/unitless": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
+      "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
+    },
+    "@emotion/utils": {
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.11.3.tgz",
+      "integrity": "sha512-0o4l6pZC+hI88+bzuaX/6BgOvQVhbt2PfmxauVaYOGgbsAw14wdKyvMCZXnsnsHys94iadcF+RG/wZyx6+ZZBw=="
+    },
+    "@emotion/weak-memoize": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz",
+      "integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA=="
+    },
+    "@itsjonq/is": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@itsjonq/is/-/is-0.0.2.tgz",
+      "integrity": "sha512-P0Ug+chfjCV1JV8MUxAGPz0BM76yDlR76AIfPwRZ6mAJW56k6b9j0s2cIcEsEAu0gNj/RJD1STw777AQyBN3CQ=="
     },
     "@jest/console": {
       "version": "24.9.0",
@@ -2928,84 +3382,99 @@
       }
     },
     "@material-ui/core": {
-      "version": "4.8.3",
-      "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-4.8.3.tgz",
-      "integrity": "sha512-ZJbfJQmkuZCSQTf0nzpfZwizmDdCq8ruZxnPNFnhoKDqgJpMvV8TJRi8vdI9ls1tMuTqxlhyhw8556fxOpWpFQ==",
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-4.11.3.tgz",
+      "integrity": "sha512-Adt40rGW6Uds+cAyk3pVgcErpzU/qxc7KBR94jFHBYretU4AtWZltYcNsbeMn9tXL86jjVL1kuGcIHsgLgFGRw==",
       "requires": {
         "@babel/runtime": "^7.4.4",
-        "@material-ui/styles": "^4.8.2",
-        "@material-ui/system": "^4.7.1",
-        "@material-ui/types": "^4.1.1",
-        "@material-ui/utils": "^4.7.1",
+        "@material-ui/styles": "^4.11.3",
+        "@material-ui/system": "^4.11.3",
+        "@material-ui/types": "^5.1.0",
+        "@material-ui/utils": "^4.11.2",
         "@types/react-transition-group": "^4.2.0",
-        "clsx": "^1.0.2",
-        "convert-css-length": "^2.0.1",
-        "hoist-non-react-statics": "^3.2.1",
-        "normalize-scroll-left": "^0.2.0",
-        "popper.js": "^1.14.1",
+        "clsx": "^1.0.4",
+        "hoist-non-react-statics": "^3.3.2",
+        "popper.js": "1.16.1-lts",
         "prop-types": "^15.7.2",
-        "react-is": "^16.8.0",
-        "react-transition-group": "^4.3.0"
+        "react-is": "^16.8.0 || ^17.0.0",
+        "react-transition-group": "^4.4.0"
       }
     },
     "@material-ui/icons": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/@material-ui/icons/-/icons-4.5.1.tgz",
-      "integrity": "sha512-YZ/BgJbXX4a0gOuKWb30mBaHaoXRqPanlePam83JQPZ/y4kl+3aW0Wv9tlR70hB5EGAkEJGW5m4ktJwMgxQAeA==",
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/@material-ui/icons/-/icons-4.11.2.tgz",
+      "integrity": "sha512-fQNsKX2TxBmqIGJCSi3tGTO/gZ+eJgWmMJkgDiOfyNaunNaxcklJQFaFogYcFl0qFuaEz1qaXYXboa/bUXVSOQ==",
       "requires": {
         "@babel/runtime": "^7.4.4"
       }
     },
     "@material-ui/styles": {
-      "version": "4.8.2",
-      "resolved": "https://registry.npmjs.org/@material-ui/styles/-/styles-4.8.2.tgz",
-      "integrity": "sha512-r5U+93pkpwQOmHTmwyn2sqTio6PHd873xvSHiKP6fdybAXXX6CZgVvh3W8saZNbYr/QXsS8OHmFv7sYJLt5Yfg==",
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@material-ui/styles/-/styles-4.11.3.tgz",
+      "integrity": "sha512-HzVzCG+PpgUGMUYEJ2rTEmQYeonGh41BYfILNFb/1ueqma+p1meSdu4RX6NjxYBMhf7k+jgfHFTTz+L1SXL/Zg==",
       "requires": {
         "@babel/runtime": "^7.4.4",
-        "@emotion/hash": "^0.7.4",
-        "@material-ui/types": "^4.1.1",
-        "@material-ui/utils": "^4.7.1",
-        "clsx": "^1.0.2",
+        "@emotion/hash": "^0.8.0",
+        "@material-ui/types": "^5.1.0",
+        "@material-ui/utils": "^4.11.2",
+        "clsx": "^1.0.4",
         "csstype": "^2.5.2",
-        "hoist-non-react-statics": "^3.2.1",
-        "jss": "^10.0.0",
-        "jss-plugin-camel-case": "^10.0.0",
-        "jss-plugin-default-unit": "^10.0.0",
-        "jss-plugin-global": "^10.0.0",
-        "jss-plugin-nested": "^10.0.0",
-        "jss-plugin-props-sort": "^10.0.0",
-        "jss-plugin-rule-value-function": "^10.0.0",
-        "jss-plugin-vendor-prefixer": "^10.0.0",
+        "hoist-non-react-statics": "^3.3.2",
+        "jss": "^10.5.1",
+        "jss-plugin-camel-case": "^10.5.1",
+        "jss-plugin-default-unit": "^10.5.1",
+        "jss-plugin-global": "^10.5.1",
+        "jss-plugin-nested": "^10.5.1",
+        "jss-plugin-props-sort": "^10.5.1",
+        "jss-plugin-rule-value-function": "^10.5.1",
+        "jss-plugin-vendor-prefixer": "^10.5.1",
         "prop-types": "^15.7.2"
+      },
+      "dependencies": {
+        "csstype": {
+          "version": "2.6.14",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.14.tgz",
+          "integrity": "sha512-2mSc+VEpGPblzAxyeR+vZhJKgYg0Og0nnRi7pmRXFYYxSfnOnW8A5wwQb4n4cE2nIOzqKOAzLCaEX6aBmNEv8A=="
+        }
       }
     },
     "@material-ui/system": {
-      "version": "4.7.1",
-      "resolved": "https://registry.npmjs.org/@material-ui/system/-/system-4.7.1.tgz",
-      "integrity": "sha512-zH02p+FOimXLSKOW/OT2laYkl9bB3dD1AvnZqsHYoseUaq0aVrpbl2BGjQi+vJ5lg8w73uYlt9zOWzb3+1UdMQ==",
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@material-ui/system/-/system-4.11.3.tgz",
+      "integrity": "sha512-SY7otguNGol41Mu2Sg6KbBP1ZRFIbFLHGK81y4KYbsV2yIcaEPOmsCK6zwWlp+2yTV3J/VwT6oSBARtGIVdXPw==",
       "requires": {
         "@babel/runtime": "^7.4.4",
-        "@material-ui/utils": "^4.7.1",
+        "@material-ui/utils": "^4.11.2",
+        "csstype": "^2.5.2",
         "prop-types": "^15.7.2"
+      },
+      "dependencies": {
+        "csstype": {
+          "version": "2.6.14",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.14.tgz",
+          "integrity": "sha512-2mSc+VEpGPblzAxyeR+vZhJKgYg0Og0nnRi7pmRXFYYxSfnOnW8A5wwQb4n4cE2nIOzqKOAzLCaEX6aBmNEv8A=="
+        }
       }
     },
     "@material-ui/types": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@material-ui/types/-/types-4.1.1.tgz",
-      "integrity": "sha512-AN+GZNXytX9yxGi0JOfxHrRTbhFybjUJ05rnsBVjcB+16e466Z0Xe5IxawuOayVZgTBNDxmPKo5j4V6OnMtaSQ==",
-      "requires": {
-        "@types/react": "*"
-      }
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@material-ui/types/-/types-5.1.0.tgz",
+      "integrity": "sha512-7cqRjrY50b8QzRSYyhSpx4WRw2YuO0KKIGQEVk5J8uoz2BanawykgZGoWEqKm7pVIbzFDN0SpPcVV4IhOFkl8A=="
     },
     "@material-ui/utils": {
-      "version": "4.7.1",
-      "resolved": "https://registry.npmjs.org/@material-ui/utils/-/utils-4.7.1.tgz",
-      "integrity": "sha512-+ux0SlLdlehvzCk2zdQ3KiS3/ylWvuo/JwAGhvb8dFVvwR21K28z0PU9OQW2PGogrMEdvX3miEI5tGxTwwWiwQ==",
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/@material-ui/utils/-/utils-4.11.2.tgz",
+      "integrity": "sha512-Uul8w38u+PICe2Fg2pDKCaIG7kOyhowZ9vjiC1FsVwPABTW8vPPKfF6OvxRq3IiBaI1faOJmgdvMG7rMJARBhA==",
       "requires": {
         "@babel/runtime": "^7.4.4",
         "prop-types": "^15.7.2",
-        "react-is": "^16.8.0"
+        "react-is": "^16.8.0 || ^17.0.0"
       }
+    },
+    "@popperjs/core": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.6.0.tgz",
+      "integrity": "sha512-cPqjjzuFWNK3BSKLm0abspP0sp/IGOli4p5I5fKFAzdS8fvjdOwDCfZqAaIiXd9lPkOWi3SUUfZof3hEb7J/uw=="
     },
     "@romainberger/css-diff": {
       "version": "1.0.3",
@@ -3074,31 +3543,31 @@
       }
     },
     "@tannin/compile": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@tannin/compile/-/compile-1.0.3.tgz",
-      "integrity": "sha512-OkPHvaM/hIHdSco3+ZO1hzkOtfEddn5a0veWft2aDLvKnbdj9VusiLKNdEE9by3hCZIIcb9aWF+iBorhfrQOfw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@tannin/compile/-/compile-1.1.0.tgz",
+      "integrity": "sha512-n8m9eNDfoNZoxdvWiTfW/hSPhehzLJ3zW7f8E7oT6mCROoMNWCB4TYtv041+2FMAxweiE0j7i1jubQU4MEC/Gg==",
       "requires": {
-        "@tannin/evaluate": "^1.1.1",
-        "@tannin/postfix": "^1.0.2"
+        "@tannin/evaluate": "^1.2.0",
+        "@tannin/postfix": "^1.1.0"
       }
     },
     "@tannin/evaluate": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@tannin/evaluate/-/evaluate-1.1.1.tgz",
-      "integrity": "sha512-ALuSZHjrLHGnw0WxsHDHde74FJ2WW0Ck4rg3QBxFBCmxd6Wsac+e0HXfJ++Qion15LIOCmFhyVpWzawMgeBA8Q=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@tannin/evaluate/-/evaluate-1.2.0.tgz",
+      "integrity": "sha512-3ioXvNowbO/wSrxsDG5DKIMxC81P0QrQTYai8zFNY+umuoHWRPbQ/TuuDEOju9E+jQDXmj6yI5GyejNuh8I+eg=="
     },
     "@tannin/plural-forms": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@tannin/plural-forms/-/plural-forms-1.0.3.tgz",
-      "integrity": "sha512-IUr9+FiCnzCiB9aRio3FVNR8TNL9SmX2zkV6tmfWWwSclX4uTCykoGsDhTGKK+sZnMrdPCTmb/OxbtGNdVyV4g==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@tannin/plural-forms/-/plural-forms-1.1.0.tgz",
+      "integrity": "sha512-xl9R2mDZO/qiHam1AgMnAES6IKIg7OBhcXqy6eDsRCdXuxAFPcjrej9HMjyCLE0DJ/8cHf0i5OQTstuBRhpbHw==",
       "requires": {
-        "@tannin/compile": "^1.0.3"
+        "@tannin/compile": "^1.1.0"
       }
     },
     "@tannin/postfix": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@tannin/postfix/-/postfix-1.0.2.tgz",
-      "integrity": "sha512-Nggtk7/ljfNPpAX8CjxxLkMKuO6u2gH1ozmTvGclWF2pNcxTf6YGghYNYNWZRKrimXGhQ8yZqvAHep7h80K04g=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@tannin/postfix/-/postfix-1.1.0.tgz",
+      "integrity": "sha512-oocsqY7g0cR+Gur5jRQLSrX2OtpMLMse1I10JQBm8CdGMrDkh1Mg2gjsiquMHRtBs4Qwu5wgEp5GgIYHk4SNPw=="
     },
     "@types/babel__core": {
       "version": "7.1.3",
@@ -3172,6 +3641,11 @@
       "integrity": "sha512-Jg1F+bmxcpENHP23sVKkNuU3uaxPnsBMW0cLjleiikFKomJQbsn0Cqk2yDvQArqzZN6ABfBkZ0To7pQ8sLdWDg==",
       "dev": true
     },
+    "@types/parse-json": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
+    },
     "@types/prop-types": {
       "version": "15.7.3",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
@@ -3184,18 +3658,26 @@
       "dev": true
     },
     "@types/react": {
-      "version": "16.9.17",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.17.tgz",
-      "integrity": "sha512-UP27In4fp4sWF5JgyV6pwVPAQM83Fj76JOcg02X5BZcpSu5Wx+fP9RMqc2v0ssBoQIFvD5JdKY41gjJJKmw6Bg==",
+      "version": "16.14.3",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.3.tgz",
+      "integrity": "sha512-zPrXn03hmPYqh9DznqSFQsoRtrQ4aHgnZDO+hMGvsE/PORvDTdJCHQ6XvJV31ic+0LzF73huPFXUb++W6Kri0Q==",
       "requires": {
         "@types/prop-types": "*",
-        "csstype": "^2.2.0"
+        "csstype": "^3.0.2"
+      }
+    },
+    "@types/react-dom": {
+      "version": "16.9.10",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.9.10.tgz",
+      "integrity": "sha512-ItatOrnXDMAYpv6G8UCk2VhbYVTjZT9aorLtA/OzDN9XJ2GKcfam68jutoAcILdRjsRUO8qb7AmyObF77Q8QFw==",
+      "requires": {
+        "@types/react": "^16"
       }
     },
     "@types/react-transition-group": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.2.3.tgz",
-      "integrity": "sha512-Hk8jiuT7iLOHrcjKP/ZVSyCNXK73wJAUz60xm0mVhiRujrdiI++j4duLiL282VGxwAgxetHQFfqA29LgEeSkFA==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.0.tgz",
+      "integrity": "sha512-/QfLHGpu+2fQOqQaXh8MG9q03bFENooTb/it4jr5kKaZlDQfWvjqWZg48AwzPVMBHlRuTRAY7hRHCEOXz5kV6w==",
       "requires": {
         "@types/react": "*"
       }
@@ -3398,56 +3880,32 @@
       }
     },
     "@wordpress/a11y": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-2.6.0.tgz",
-      "integrity": "sha512-9g+OYD/WzW5CfqiygOtc9n+jm7gMPD87TNSWcPqOJ75vSbqHjlwtvk1FXtxUPbkwN1TbFXHoD8ciq5abK55jQg==",
+      "version": "2.14.3",
+      "resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-2.14.3.tgz",
+      "integrity": "sha512-5K/wyI8c9VhW+3sk54SPOwLLBF4rkj8gqUCH4NWI4TgsFMwPcMcIOf0o+vwKG9CkRKqzMs29apzJEbkiQf4TqA==",
       "requires": {
-        "@babel/runtime": "^7.4.4",
-        "@wordpress/dom-ready": "^2.6.0"
+        "@babel/runtime": "^7.12.5",
+        "@wordpress/dom-ready": "^2.12.1",
+        "@wordpress/i18n": "^3.18.0"
       }
     },
     "@wordpress/api-fetch": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-3.9.0.tgz",
-      "integrity": "sha512-Z9n1IZcgZPLGcxH8wtPAMEHM4bfLRumlT6GVZ/xRS69iuty+Qnc7MvqSQhKTvgMR6Mb1crzc/yQje8R1vX9EDA==",
+      "version": "3.21.5",
+      "resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-3.21.5.tgz",
+      "integrity": "sha512-x99C2h7UqxL/pWyZ5AR8ZbbC1na5KZyaQuZ4IR6DuRb6O8vwBcCV3jMesh1A4R+cNxFQZNORlYuNT/bcvdhl1A==",
       "requires": {
-        "@babel/runtime": "^7.4.4",
-        "@wordpress/i18n": "^3.8.0",
-        "@wordpress/url": "^2.9.0"
-      },
-      "dependencies": {
-        "@wordpress/i18n": {
-          "version": "3.8.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.8.0.tgz",
-          "integrity": "sha512-SXheA3E2aA/w5/cubrIho3fCLY5Jb7zdpg7NGS3DFXYEe5VICMdmgNxeYFoeyNSw2IkNmphJhsZXzVIMf92dYQ==",
-          "requires": {
-            "@babel/runtime": "^7.4.4",
-            "gettext-parser": "^1.3.1",
-            "lodash": "^4.17.15",
-            "memize": "^1.0.5",
-            "sprintf-js": "^1.1.1",
-            "tannin": "^1.1.0"
-          }
-        },
-        "lodash": {
-          "version": "4.17.15",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
-        },
-        "sprintf-js": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
-          "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
-        }
+        "@babel/runtime": "^7.12.5",
+        "@wordpress/i18n": "^3.18.0",
+        "@wordpress/url": "^2.21.2"
       }
     },
     "@wordpress/autop": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/autop/-/autop-2.3.0.tgz",
-      "integrity": "sha512-j6vm65yragfH7iDLwEdhSP++69ntOabkyPiuYURMILRmPmystZ29R8T7tHrt7SgnE/YOwRqFH45DRq74u9ciDg==",
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/autop/-/autop-2.11.1.tgz",
+      "integrity": "sha512-3TUAtcDneDqZeYF0AqGDm2RD/8Ed9eCWZwnMScx6zyvr6llmuhd4QKmGrnq02Rd//rqTSbsJEeFIT6FACxzJnA==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.4.4"
+        "@babel/runtime": "^7.12.5"
       }
     },
     "@wordpress/babel-plugin-import-jsx-pragma": {
@@ -3457,133 +3915,207 @@
       "dev": true
     },
     "@wordpress/base-styles": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-1.2.0.tgz",
-      "integrity": "sha512-jiU7naQ5ARrPhnCOvSXHudDX2zFTW4XfqmqKqnMzZC4A4fjywwfC00P98bcKXvSEhev5IH8BSxS+UxNzbUpPxQ=="
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-3.3.2.tgz",
+      "integrity": "sha512-GPvvfRUXAnAhsND92w8KEydAwtfim+6Xr8WUt9M+8ryPxlg85lRRdcpJkMB8sfqtBzBmWvXUsKmiimGew5o6zA=="
     },
     "@wordpress/blob": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/blob/-/blob-2.4.0.tgz",
-      "integrity": "sha512-VUHUTABAR7xgZtP1qRYDNTZqeRlrpSqjAAczk80YkpKQOq2LD+HhxBpktBQ06YchV+OTwXh0l853IRDOUsGwWw==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/blob/-/blob-2.12.1.tgz",
+      "integrity": "sha512-6undS4OASjzY8YyNVoJp1jToQJd6hgvFLgcKugN5escOLqwsVJKbhFnUWBBSmtWLmcLOyTBXWQDp5ZUB8p35MQ==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.4.4"
+        "@babel/runtime": "^7.12.5"
       }
     },
     "@wordpress/block-serialization-default-parser": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/block-serialization-default-parser/-/block-serialization-default-parser-3.2.0.tgz",
-      "integrity": "sha512-2e079+2TIAD+H+HX3LZB8SZqzfVD4VcqYnH1/pTdppPcgtcI+4o1Fyrwqm/23JPOhDN/++QCHjrDTBySWvVX9w==",
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/block-serialization-default-parser/-/block-serialization-default-parser-3.9.1.tgz",
+      "integrity": "sha512-Pr0JGWAX0xS3cP7kVBZCrzfVqgeVU0Nz8+FuIXAtKEyCtgCO+bbmdfGaaRMnlSh6lO6r7MZ7wjPMqdfoVMKl6Q==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.4.4"
-      }
-    },
-    "@wordpress/block-serialization-spec-parser": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/block-serialization-spec-parser/-/block-serialization-spec-parser-3.1.0.tgz",
-      "integrity": "sha512-OSMLDj+FvHWSJYXkNSXLeovaiuNKrkXjVKLKWW9MQjI4sxaVFypEG9WeTpYmjDMXmTj+om9WL/1Uj0aUv1i5TA==",
-      "dev": true,
-      "requires": {
-        "pegjs": "^0.10.0"
+        "@babel/runtime": "^7.12.5"
       }
     },
     "@wordpress/blocks": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-6.4.0.tgz",
-      "integrity": "sha512-+cLkTZ0PQCLkhnKnfNGWoZE8FAp2sREevPLb3UIdT+3Dh2yBijuUanP9UPGRzpFu6vQRy/C7xXGnXevPJUeEVg==",
+      "version": "6.25.2",
+      "resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-6.25.2.tgz",
+      "integrity": "sha512-dYleqt8o030Bw2dV6HKrafhcTQf/AqOAVagA9rBKRVfl6ABrm26Gb8YsgwTMMrxIIGRy9uqqqNWH1o8ae3JE2A==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.4.4",
-        "@wordpress/autop": "^2.3.0",
-        "@wordpress/blob": "^2.4.0",
-        "@wordpress/block-serialization-default-parser": "^3.2.0",
-        "@wordpress/block-serialization-spec-parser": "^3.1.0",
-        "@wordpress/data": "^4.6.0",
-        "@wordpress/dom": "^2.3.0",
-        "@wordpress/element": "^2.5.0",
-        "@wordpress/hooks": "^2.4.0",
-        "@wordpress/html-entities": "^2.4.0",
-        "@wordpress/i18n": "^3.5.0",
-        "@wordpress/is-shallow-equal": "^1.4.0",
-        "@wordpress/shortcode": "^2.3.0",
+        "@babel/runtime": "^7.12.5",
+        "@wordpress/autop": "^2.11.0",
+        "@wordpress/blob": "^2.12.0",
+        "@wordpress/block-serialization-default-parser": "^3.9.0",
+        "@wordpress/compose": "^3.24.0",
+        "@wordpress/data": "^4.26.2",
+        "@wordpress/deprecated": "^2.11.0",
+        "@wordpress/dom": "^2.16.1",
+        "@wordpress/element": "^2.19.0",
+        "@wordpress/hooks": "^2.11.0",
+        "@wordpress/html-entities": "^2.10.0",
+        "@wordpress/i18n": "^3.17.0",
+        "@wordpress/icons": "^2.9.0",
+        "@wordpress/is-shallow-equal": "^3.0.0",
+        "@wordpress/shortcode": "^2.12.0",
         "hpq": "^1.3.0",
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.19",
         "rememo": "^3.0.0",
-        "showdown": "^1.8.6",
+        "showdown": "^1.9.1",
         "simple-html-tokenizer": "^0.5.7",
         "tinycolor2": "^1.4.1",
-        "uuid": "^3.3.2"
+        "uuid": "^8.3.0"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
+        },
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+          "dev": true
+        }
       }
     },
     "@wordpress/browserslist-config": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-2.5.0.tgz",
-      "integrity": "sha512-cspE4iJ87YjweKAtnIsCxm7ZJQ/ved3TdRJWS0DX/0AOukoRhOMYh7CP1aVc0M3J1kB4LtTY7u3HOcqF2Yf2VA==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-2.7.0.tgz",
+      "integrity": "sha512-pB45JlfmHuEigNFZ1X+CTgIsOT3/TTb9iZxw1DHXge/7ytY8FNhtcNwTfF9IgnS6/xaFRZBqzw4DyH4sP1Lyxg==",
       "dev": true
     },
     "@wordpress/components": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-7.4.0.tgz",
-      "integrity": "sha512-riVey0Z5835YdPZLWFSAs/4Hzo0nr7WA/393mRXwGuUtkqdk7ia++5emKfhyaCLYbinVBd6366xFFfiFxxcsCA==",
+      "version": "12.0.5",
+      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-12.0.5.tgz",
+      "integrity": "sha512-0og7rr1fgS93/zBtGIglFtfFfS28O9B/LRA10ZHZogziRrC26pjx8twcg6Yui1UutJwj8FzJeAzNrQoxeNmysA==",
       "requires": {
-        "@babel/runtime": "^7.4.4",
-        "@wordpress/a11y": "^2.3.0",
-        "@wordpress/api-fetch": "^3.2.0",
-        "@wordpress/compose": "^3.3.0",
-        "@wordpress/dom": "^2.3.0",
-        "@wordpress/element": "^2.4.0",
-        "@wordpress/hooks": "^2.3.0",
-        "@wordpress/i18n": "^3.4.0",
-        "@wordpress/is-shallow-equal": "^1.3.0",
-        "@wordpress/keycodes": "^2.3.0",
-        "@wordpress/rich-text": "^3.3.0",
-        "@wordpress/url": "^2.6.0",
+        "@babel/runtime": "^7.12.5",
+        "@emotion/core": "^10.1.1",
+        "@emotion/css": "^10.0.22",
+        "@emotion/native": "^10.0.22",
+        "@emotion/styled": "^10.0.23",
+        "@wordpress/a11y": "^2.14.3",
+        "@wordpress/compose": "^3.24.3",
+        "@wordpress/date": "^3.13.1",
+        "@wordpress/deprecated": "^2.11.1",
+        "@wordpress/dom": "^2.16.2",
+        "@wordpress/element": "^2.19.1",
+        "@wordpress/hooks": "^2.11.1",
+        "@wordpress/i18n": "^3.18.0",
+        "@wordpress/icons": "^2.9.1",
+        "@wordpress/is-shallow-equal": "^3.0.1",
+        "@wordpress/keycodes": "^2.18.3",
+        "@wordpress/primitives": "^1.11.1",
+        "@wordpress/rich-text": "^3.24.5",
+        "@wordpress/warning": "^1.3.1",
+        "@wp-g2/components": "^0.0.140",
+        "@wp-g2/context": "^0.0.140",
+        "@wp-g2/styles": "^0.0.140",
+        "@wp-g2/utils": "^0.0.140",
         "classnames": "^2.2.5",
-        "clipboard": "^2.0.1",
-        "diff": "^3.5.0",
         "dom-scroll-into-view": "^1.2.1",
-        "lodash": "^4.17.11",
-        "memize": "^1.0.5",
+        "downshift": "^6.0.15",
+        "gradient-parser": "^0.1.5",
+        "highlight-words-core": "^1.2.2",
+        "lodash": "^4.17.19",
+        "memize": "^1.1.0",
         "moment": "^2.22.1",
-        "mousetrap": "^1.6.2",
-        "re-resizable": "^4.7.1",
-        "react-click-outside": "^3.0.0",
+        "re-resizable": "^6.4.0",
         "react-dates": "^17.1.1",
+        "react-merge-refs": "^1.0.0",
+        "react-resize-aware": "^3.1.0",
+        "react-spring": "^8.0.20",
+        "react-use-gesture": "^9.0.0",
+        "reakit": "^1.3.5",
         "rememo": "^3.0.0",
-        "tinycolor2": "^1.4.1",
-        "uuid": "^3.3.2"
+        "tinycolor2": "^1.4.2",
+        "uuid": "^8.3.0"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+        },
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+        }
       }
     },
     "@wordpress/compose": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.4.0.tgz",
-      "integrity": "sha512-mrOS0iob7fyptp8C+bMlorv4B4CAX6byfKhM6IrdV1rXFmTvTTCz7tCGwi++QXGCCifDGnQY8SpwfJ5oGMb4rg==",
+      "version": "3.24.3",
+      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.24.3.tgz",
+      "integrity": "sha512-/I8bn0BUEMr3ZEC1BgjEH+L2YlOK5Ff9lb37lO+LIZgfED9RgCCEPG4qZEWX1ELiQUk/Yz2T/dr+sVNx8JZ0+w==",
       "requires": {
-        "@babel/runtime": "^7.4.4",
-        "@wordpress/element": "^2.5.0",
-        "@wordpress/is-shallow-equal": "^1.4.0",
-        "lodash": "^4.17.11"
+        "@babel/runtime": "^7.12.5",
+        "@wordpress/deprecated": "^2.11.1",
+        "@wordpress/dom": "^2.16.2",
+        "@wordpress/element": "^2.19.1",
+        "@wordpress/is-shallow-equal": "^3.0.1",
+        "@wordpress/keycodes": "^2.18.3",
+        "@wordpress/priority-queue": "^1.10.1",
+        "clipboard": "^2.0.1",
+        "lodash": "^4.17.19",
+        "memize": "^1.1.0",
+        "mousetrap": "^1.6.5",
+        "react-merge-refs": "^1.0.0",
+        "react-resize-aware": "^3.1.0",
+        "use-memo-one": "^1.1.1"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+        }
       }
     },
     "@wordpress/data": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-4.6.0.tgz",
-      "integrity": "sha512-42BNtWtN0ppnzbnxz0tA72KNtuEKjrIRr4PbVCw3JVrHN2Nfhbo9SiCUutReKAXGQaT4LPnO7gAGmIsdC/mBUw==",
-      "dev": true,
+      "version": "4.26.5",
+      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-4.26.5.tgz",
+      "integrity": "sha512-rOEm9V5xOergNgaTnNP3KZjg8RGtpaizEr+MhOwxSQEvmxTkystDqHAxzD0MKeQPA9jaAbzarho+9yhjlX7EdA==",
       "requires": {
-        "@babel/runtime": "^7.4.4",
-        "@wordpress/compose": "^3.4.0",
-        "@wordpress/deprecated": "^2.4.0",
-        "@wordpress/element": "^2.5.0",
-        "@wordpress/is-shallow-equal": "^1.4.0",
-        "@wordpress/priority-queue": "^1.2.0",
-        "@wordpress/redux-routine": "^3.4.0",
+        "@babel/runtime": "^7.12.5",
+        "@wordpress/compose": "^3.24.3",
+        "@wordpress/deprecated": "^2.11.1",
+        "@wordpress/element": "^2.19.1",
+        "@wordpress/is-shallow-equal": "^3.0.1",
+        "@wordpress/priority-queue": "^1.10.1",
+        "@wordpress/redux-routine": "^3.13.1",
         "equivalent-key-map": "^0.2.2",
-        "is-promise": "^2.1.0",
-        "lodash": "^4.17.11",
+        "is-promise": "^4.0.0",
+        "lodash": "^4.17.19",
+        "memize": "^1.1.0",
         "redux": "^4.0.0",
-        "turbo-combine-reducers": "^1.0.2"
+        "turbo-combine-reducers": "^1.0.2",
+        "use-memo-one": "^1.1.1"
+      },
+      "dependencies": {
+        "is-promise": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+          "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="
+        },
+        "lodash": {
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+        }
+      }
+    },
+    "@wordpress/date": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/date/-/date-3.13.1.tgz",
+      "integrity": "sha512-q1AQVF8OuVx2U3Srv/qvQxgoIe0nUCLu0vYtzxDIo0VjKSxDFrs90EdFlat3CfwOiqbVowAvQFRTxTlGEV8LoQ==",
+      "requires": {
+        "@babel/runtime": "^7.12.5",
+        "moment": "^2.22.1",
+        "moment-timezone": "^0.5.31"
       }
     },
     "@wordpress/dependency-extraction-webpack-plugin": {
@@ -3598,322 +4130,424 @@
       }
     },
     "@wordpress/deprecated": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-2.4.0.tgz",
-      "integrity": "sha512-gsK1ist0Oook6iod+v5P1D48TWX/47jO7tOLoSwnhO1F4Qtm73bBtUofx2MntajRsxilB1j+wHXDmDUTV477XA==",
-      "dev": true,
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-2.11.1.tgz",
+      "integrity": "sha512-ri5M3TSAhonRN9G67KDwu8AXthrxay/1lLwBVbRA+6Dpj6hpC4qUBxOP4Yx5VLYOJEJW2YJx3w3G3XFYiyqfFg==",
       "requires": {
-        "@babel/runtime": "^7.4.4",
-        "@wordpress/hooks": "^2.4.0"
+        "@babel/runtime": "^7.12.5",
+        "@wordpress/hooks": "^2.11.1"
       }
     },
     "@wordpress/dom": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-2.3.0.tgz",
-      "integrity": "sha512-cy/AD7gcbQmYJd8hSsuOVhdvkdFARsP1UBirZ1nwQZtQyjwAqWQzMdLUml5PzeczhEZQlo9vzJGo8fGwQvpxEw==",
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-2.16.2.tgz",
+      "integrity": "sha512-w95LZR98sqmxkXm5RtynXi+/tIb5vw2gSBAWlbc0OHhZkC2DC9oy6QDR0pthUUYCa3NJht4KMyhBbwN/cePq8w==",
       "requires": {
-        "@babel/runtime": "^7.4.4",
-        "lodash": "^4.17.11"
+        "@babel/runtime": "^7.12.5",
+        "lodash": "^4.17.19"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+        }
       }
     },
     "@wordpress/dom-ready": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-2.6.0.tgz",
-      "integrity": "sha512-Fzz2TJrxclxp3W6HG4B385ReVVgteaHp9AobtfrGWZEYh08wK/IJvJOoI0PbThw1kQp8IO9S4pw/MJSNRszlTw==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-2.12.1.tgz",
+      "integrity": "sha512-nprG8FFPexRZ3t3m0ATNmpZQ2OJ524IoUivwL+YT9cpdKMQ3jjd/aNac3jhnTzeol+OlDnGUxft0V0ch/j3AaQ==",
       "requires": {
-        "@babel/runtime": "^7.4.4"
+        "@babel/runtime": "^7.12.5"
       }
     },
     "@wordpress/element": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.5.0.tgz",
-      "integrity": "sha512-gqtNcBkVtF//OHKJQAn4c7nwfDqsIy0UMq7ed9l6lpXOKS5ic8cw7BgNtdx4PiicV46ev9s/yHieFKWZNFpfIw==",
+      "version": "2.19.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.19.1.tgz",
+      "integrity": "sha512-mjgFYJzSCNlQBFXvVP806pJiKh9nSIB+NeAVUVwMOntek4aCdKk+t4aTU2cRmktZI2QRySmy+lyDrY2aVkwdyg==",
       "requires": {
-        "@babel/runtime": "^7.4.4",
-        "@wordpress/escape-html": "^1.4.0",
-        "lodash": "^4.17.11",
-        "react": "^16.8.4",
-        "react-dom": "^16.8.4"
+        "@babel/runtime": "^7.12.5",
+        "@types/react": "^16.9.0",
+        "@types/react-dom": "^16.9.0",
+        "@wordpress/escape-html": "^1.11.1",
+        "lodash": "^4.17.19",
+        "react": "^16.13.1",
+        "react-dom": "^16.13.1"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+        }
       }
     },
     "@wordpress/escape-html": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-1.4.0.tgz",
-      "integrity": "sha512-WkpSumSZPSsopZtUJImHPyhlf/ZFHbbAm9zIsPFwHM7Dlh437p3Yiu3+tuAiE2Rs6XzElP0tD8eEULpkxPeFFA==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-1.11.1.tgz",
+      "integrity": "sha512-kthpdAijVY1tSGnSy1kuKM5+L/u7uxzSBNDusqKcfeSgczfHlfKwkkA82SMHzsSR/WicXDaWBfcEMqfb4PENiQ==",
       "requires": {
-        "@babel/runtime": "^7.4.4"
+        "@babel/runtime": "^7.12.5"
       }
     },
     "@wordpress/hooks": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-2.4.0.tgz",
-      "integrity": "sha512-z3+8Yq4IQ3DOvUF4VsXOfntdyk1fJ8RZBYlZTW8WfmHV7VKTDbX3LfHXmC2VCjXhVkeWQVKozi2weoEYopfGKA==",
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-2.11.1.tgz",
+      "integrity": "sha512-20nsvmLH5/iw9P6M7kiEBBQ7X7G3pEbqED/aN5dqkMCklDyar+OZqYBzdpGGsthXVYgomfNy6QQZWELkGJbcbw==",
       "requires": {
-        "@babel/runtime": "^7.4.4"
+        "@babel/runtime": "^7.12.5"
       }
     },
     "@wordpress/html-entities": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-2.4.0.tgz",
-      "integrity": "sha512-rhuZDWk9LAsmhf9jitn7BP92h6yYTdi1d2j5lU9cSR8FaBRctyimAP/5KdZJ/fCOBzmBH7yXnByuKEN9/ovR0w==",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-2.10.1.tgz",
+      "integrity": "sha512-7nQY4ftrB1/kCDnoi3qyr/lQILWTGaNOEfAZ4ky7MvQvQ+7HTblfx0syrSy5P/rsEBaIjv69+nyaNeYI+9EbOQ==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.4.4"
+        "@babel/runtime": "^7.12.5"
       }
     },
     "@wordpress/i18n": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.5.0.tgz",
-      "integrity": "sha512-QAYFsHe/raG0MPUX32gCmuSM6UN/5gWCVSFWxOVSuXVuzPP5WnL78CgpuXtUresDZXTJm3FrFcB9IKvh93e1DQ==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.18.0.tgz",
+      "integrity": "sha512-e1uFWhWYnT0B6s3hyy+xS0S3bwabrvkZA84xxitiIcQvGnZDUPntqv6M9+VrgJVlmd2MR2TbCGJ5xKFAVFr/gA==",
       "requires": {
-        "@babel/runtime": "^7.4.4",
+        "@babel/runtime": "^7.12.5",
+        "@wordpress/hooks": "^2.11.1",
         "gettext-parser": "^1.3.1",
-        "lodash": "^4.17.11",
-        "memize": "^1.0.5",
+        "lodash": "^4.17.19",
+        "memize": "^1.1.0",
         "sprintf-js": "^1.1.1",
-        "tannin": "^1.0.1"
+        "tannin": "^1.2.0"
       },
       "dependencies": {
+        "lodash": {
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+        },
         "sprintf-js": {
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
           "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
         }
+      }
+    },
+    "@wordpress/icons": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-2.9.1.tgz",
+      "integrity": "sha512-SLP3cJpnY2jNvoCpbBiaM37N3vZmfqqJsNspkRQXuPkLqBLu576GV+WX7l1Eqq6i12/nLUfHu3blhOAQrNtxYQ==",
+      "requires": {
+        "@babel/runtime": "^7.12.5",
+        "@wordpress/element": "^2.19.1",
+        "@wordpress/primitives": "^1.11.1"
       }
     },
     "@wordpress/is-shallow-equal": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-1.4.0.tgz",
-      "integrity": "sha512-cghwkh4Ui4o52zdiMCD10dyR0y1K5rf7Cb92J8rF1+DhyoNgYRYWo2OtYLN8RPpsHdo4KPW8noL4SIuKse+Zkw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-3.0.1.tgz",
+      "integrity": "sha512-enrOrfArOImeqT207i3ayZ0yPCnc/LvvvSPEd4aSPNV27zC7sTor/ksoN2NNyrGaC9P2pZ6IlkMEr+BCN02OXw==",
       "requires": {
-        "@babel/runtime": "^7.4.4"
+        "@babel/runtime": "^7.12.5"
       }
     },
     "@wordpress/keycodes": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-2.8.0.tgz",
-      "integrity": "sha512-c1YQZbMEPplEgbXxxSDBUxG92zxwCB//SvVJw+poHBiQi+bcEuH/J/xezAXk4tfJO/gtb1r3LpFjcZqxZWc8SA==",
+      "version": "2.18.3",
+      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-2.18.3.tgz",
+      "integrity": "sha512-Lenyw+K2KgiqddBv5fDCh2JRfXFrONWNvPfv1DKXzHXTvBSI0JkU1RVP5WZTcVuEtctCZWL5JbhrkG2I26w68g==",
       "requires": {
-        "@babel/runtime": "^7.4.4",
-        "@wordpress/i18n": "^3.8.0",
-        "lodash": "^4.17.15"
+        "@babel/runtime": "^7.12.5",
+        "@wordpress/i18n": "^3.18.0",
+        "lodash": "^4.17.19"
       },
       "dependencies": {
-        "@wordpress/i18n": {
-          "version": "3.8.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.8.0.tgz",
-          "integrity": "sha512-SXheA3E2aA/w5/cubrIho3fCLY5Jb7zdpg7NGS3DFXYEe5VICMdmgNxeYFoeyNSw2IkNmphJhsZXzVIMf92dYQ==",
-          "requires": {
-            "@babel/runtime": "^7.4.4",
-            "gettext-parser": "^1.3.1",
-            "lodash": "^4.17.15",
-            "memize": "^1.0.5",
-            "sprintf-js": "^1.1.1",
-            "tannin": "^1.1.0"
-          }
-        },
         "lodash": {
-          "version": "4.17.15",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
-        },
-        "sprintf-js": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
-          "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
         }
       }
     },
-    "@wordpress/priority-queue": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-1.2.0.tgz",
-      "integrity": "sha512-po70nJhWK3oBhc9D/rBv2RFsX9do7fIABdUSVNAFQ+vRnatxlZTxJ6z8A2rtY71tiV244qgy3In6H7n1i6QO7A==",
-      "dev": true,
+    "@wordpress/primitives": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-1.11.1.tgz",
+      "integrity": "sha512-xYxcQ0JGnYjaSo1oXCapFl69jBjOPT8iuLf9RC1TulmZFnQsvqIv7Mu9VW9YPTg4gMXAavLD2EB+fqXdI1NNhQ==",
       "requires": {
-        "@babel/runtime": "^7.4.4"
+        "@babel/runtime": "^7.12.5",
+        "@wordpress/element": "^2.19.1",
+        "classnames": "^2.2.5"
+      }
+    },
+    "@wordpress/priority-queue": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-1.10.1.tgz",
+      "integrity": "sha512-O7W4ktSW6egVtW4fvyUnnetNODbtjuKj6G7AyXUPNyrmKBma0g/nGIRed3iA7rOfLyjzyzh7ZkP0sSENXKAvQQ==",
+      "requires": {
+        "@babel/runtime": "^7.12.5"
       }
     },
     "@wordpress/redux-routine": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-3.4.0.tgz",
-      "integrity": "sha512-v4aQWBQjjsZ3qEbA1vnI/do7lEx8xBI1rVJKEOzN98+xfweAVtTQLW+2+bpQQDPTs+SUrp5LAqLgWLqFP6V1RQ==",
-      "dev": true,
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-3.13.1.tgz",
+      "integrity": "sha512-4VPeA27BEmmiLW14EL0fZunxbiUrMKqnrbXH7KGQU6YOmarKWCw1efgD+jqpatW+3iUj38Fx4obnlVs40GcXsg==",
       "requires": {
-        "@babel/runtime": "^7.4.4",
-        "is-promise": "^2.1.0",
+        "@babel/runtime": "^7.12.5",
+        "is-promise": "^4.0.0",
+        "lodash": "^4.17.19",
         "rungen": "^0.3.2"
+      },
+      "dependencies": {
+        "is-promise": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+          "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="
+        },
+        "lodash": {
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+        }
       }
     },
     "@wordpress/rich-text": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-3.10.0.tgz",
-      "integrity": "sha512-gFzVRXDmGIolvcGRejg4LhoAQa2UALMOPnO96bl8zVNTAuk7kRYLbsxQLtcwTtDgSXTVVrIZHgQ67NwbtX3fxQ==",
+      "version": "3.24.5",
+      "resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-3.24.5.tgz",
+      "integrity": "sha512-qP1z5neOytwddZp4GmEUZSwKyUFTbvZ+Xc5Ydskx+zmk8zLqEsVr/TjPi6xR0LzETcmiBSShfcwu6FtPus/x2g==",
       "requires": {
-        "@babel/runtime": "^7.4.4",
-        "@wordpress/compose": "^3.10.0",
-        "@wordpress/data": "^4.12.0",
-        "@wordpress/deprecated": "^2.6.1",
-        "@wordpress/element": "^2.10.0",
-        "@wordpress/escape-html": "^1.6.0",
-        "@wordpress/is-shallow-equal": "^1.7.0",
-        "@wordpress/keycodes": "^2.8.0",
+        "@babel/runtime": "^7.12.5",
+        "@wordpress/compose": "^3.24.3",
+        "@wordpress/data": "^4.26.5",
+        "@wordpress/deprecated": "^2.11.1",
+        "@wordpress/dom": "^2.16.2",
+        "@wordpress/element": "^2.19.1",
+        "@wordpress/escape-html": "^1.11.1",
+        "@wordpress/is-shallow-equal": "^3.0.1",
+        "@wordpress/keycodes": "^2.18.3",
         "classnames": "^2.2.5",
-        "lodash": "^4.17.15",
-        "memize": "^1.0.5",
+        "lodash": "^4.17.19",
+        "memize": "^1.1.0",
         "rememo": "^3.0.0"
       },
       "dependencies": {
-        "@wordpress/compose": {
-          "version": "3.10.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.10.0.tgz",
-          "integrity": "sha512-JE3QaUINiKxKAYb235s/5Q2hT8HifCvR7fdaIEHXjkMNfMVriVIgV1YE5I6l9gJXuT5adTwTSvsWhnRBYTl3Mw==",
-          "requires": {
-            "@babel/runtime": "^7.4.4",
-            "@wordpress/element": "^2.10.0",
-            "@wordpress/is-shallow-equal": "^1.7.0",
-            "lodash": "^4.17.15",
-            "mousetrap": "^1.6.2"
-          }
-        },
-        "@wordpress/data": {
-          "version": "4.12.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-4.12.0.tgz",
-          "integrity": "sha512-HoHBRcY0kvVNtOdLwLzHcuGZSYnW8kq0NEyB1/2ZHdKZ8WMtvAflpz2qbKwnrPml1321hfkC9I3KFtA4Ep9lDA==",
-          "requires": {
-            "@babel/runtime": "^7.4.4",
-            "@wordpress/compose": "^3.10.0",
-            "@wordpress/deprecated": "^2.6.1",
-            "@wordpress/element": "^2.10.0",
-            "@wordpress/is-shallow-equal": "^1.7.0",
-            "@wordpress/priority-queue": "^1.4.0",
-            "@wordpress/redux-routine": "^3.6.2",
-            "equivalent-key-map": "^0.2.2",
-            "is-promise": "^2.1.0",
-            "lodash": "^4.17.15",
-            "memize": "^1.0.5",
-            "redux": "^4.0.0",
-            "turbo-combine-reducers": "^1.0.2"
-          }
-        },
-        "@wordpress/deprecated": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-2.6.1.tgz",
-          "integrity": "sha512-nwCZ5pfFCZRwpEOMOVJcPZ6dmcaUfINehfZwPZA/6wK6Ol5sfc5MP22zmz30LFGsP4yqfgSugYDLA2LLAnuWqg==",
-          "requires": {
-            "@babel/runtime": "^7.4.4",
-            "@wordpress/hooks": "^2.6.0"
-          }
-        },
-        "@wordpress/element": {
-          "version": "2.10.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.10.0.tgz",
-          "integrity": "sha512-CedhhFfcubM/lsluY7JPC49VG0/Ee0chOBJ1vyDEvIJmQk0bM3sLfgt5qVK773yivVOqD9blQMO+JihnaMXF8w==",
-          "requires": {
-            "@babel/runtime": "^7.4.4",
-            "@wordpress/escape-html": "^1.6.0",
-            "lodash": "^4.17.15",
-            "react": "^16.9.0",
-            "react-dom": "^16.9.0"
-          }
-        },
-        "@wordpress/escape-html": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-1.6.0.tgz",
-          "integrity": "sha512-PD4fEg7qIB2l8+buuRmYJ5edQhvUzydu6XoCigV2G4rju3BI+MO57BcEZf1LSPfbrYqTJCca3ElNW9nNbSQthQ==",
-          "requires": {
-            "@babel/runtime": "^7.4.4"
-          }
-        },
-        "@wordpress/hooks": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-2.6.0.tgz",
-          "integrity": "sha512-93THIW9EklVkJLN3wr8PUdWqttRu/wGZgXUrM6fqqOGwm4uCL4S+jQe800kwZioRHvgW5moNLrvSdfanQ4QyEQ==",
-          "requires": {
-            "@babel/runtime": "^7.4.4"
-          }
-        },
-        "@wordpress/is-shallow-equal": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-1.7.0.tgz",
-          "integrity": "sha512-fRHTAivQlWOQVn8wu8NHM8D5sacSvY6upJ+MgWSu1Q7pqy51zaCPE2T9lhym3GC1QzABus6VjDctR8jwfNfd/g==",
-          "requires": {
-            "@babel/runtime": "^7.4.4"
-          }
-        },
-        "@wordpress/priority-queue": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-1.4.0.tgz",
-          "integrity": "sha512-7yrAGkSdtU09CzDiuu7fCjVg5tQTYsYAQv2Ril9uGb4GzQpzfupaJq9wV8SXF4vW56dMYoeHtifa+yY49IGQNw==",
-          "requires": {
-            "@babel/runtime": "^7.4.4"
-          }
-        },
-        "@wordpress/redux-routine": {
-          "version": "3.6.2",
-          "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-3.6.2.tgz",
-          "integrity": "sha512-+WxQzKzaFKLfioFxIyT8J4NqOfra4DvFK1jdAqmhLdqfdY9wuSFsJHlbt5hF5fVx32n7lidx/mGkP1ysmigkqA==",
-          "requires": {
-            "@babel/runtime": "^7.4.4",
-            "is-promise": "^2.1.0",
-            "lodash": "^4.17.15",
-            "rungen": "^0.3.2"
-          }
-        },
         "lodash": {
-          "version": "4.17.15",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
-        },
-        "react": {
-          "version": "16.12.0",
-          "resolved": "https://registry.npmjs.org/react/-/react-16.12.0.tgz",
-          "integrity": "sha512-fglqy3k5E+81pA8s+7K0/T3DBCF0ZDOher1elBFzF7O6arXJgzyu/FW+COxFvAWXJoJN9KIZbT2LXlukwphYTA==",
-          "requires": {
-            "loose-envify": "^1.1.0",
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "react-dom": {
-          "version": "16.12.0",
-          "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.12.0.tgz",
-          "integrity": "sha512-LMxFfAGrcS3kETtQaCkTKjMiifahaMySFDn71fZUNpPHZQEzmk/GiAeIT8JSOrHB23fnuCOMruL2a8NYlw+8Gw==",
-          "requires": {
-            "loose-envify": "^1.1.0",
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "scheduler": "^0.18.0"
-          }
-        },
-        "scheduler": {
-          "version": "0.18.0",
-          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.18.0.tgz",
-          "integrity": "sha512-agTSHR1Nbfi6ulI0kYNK0203joW2Y5W4po4l+v03tOoiJKpTBbxpNhWDvqc/4IcOw+KLmSiQLTasZ4cab2/UWQ==",
-          "requires": {
-            "loose-envify": "^1.1.0",
-            "object-assign": "^4.1.1"
-          }
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
         }
       }
     },
     "@wordpress/shortcode": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/shortcode/-/shortcode-2.3.0.tgz",
-      "integrity": "sha512-JVsykCMc1pvEnqM9Q+xOj1qTUCCtY0c5yOtXWMAEpyeDni99p/eROH2AIUW6hKzqSWTlAJSBLIoDR9Ih4YbcxQ==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/shortcode/-/shortcode-2.12.1.tgz",
+      "integrity": "sha512-87oQbaDKXRRU8Tdn5/O7ykK5eTkmTs1cg3DYtoNQImpA9UWUJtC27LYia1IRzc8CvWh1yz3vNRYWlHmaolkdFQ==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.4.4",
-        "lodash": "^4.17.11",
-        "memize": "^1.0.5"
+        "@babel/runtime": "^7.12.5",
+        "lodash": "^4.17.19",
+        "memize": "^1.1.0"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
+        }
       }
     },
     "@wordpress/url": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/url/-/url-2.9.0.tgz",
-      "integrity": "sha512-ntrXO42/NElNHIrezoYPjWrXNyNYqyHzvvtBVSMLwwwMf7836t/C7GACuk56O3PwQEmSikMNStHQnNCwmyeaag==",
+      "version": "2.21.2",
+      "resolved": "https://registry.npmjs.org/@wordpress/url/-/url-2.21.2.tgz",
+      "integrity": "sha512-bLHg4pTo/9mQUkK1s1MU/Sjgnzfy2AkPvPn4ObGA8/4CFkMsDhQGAVhhw5YuezcxvaJkBiKJ+BxgFJ1QKksF6w==",
       "requires": {
-        "@babel/runtime": "^7.4.4",
-        "qs": "^6.5.2"
+        "@babel/runtime": "^7.12.5",
+        "lodash": "^4.17.19",
+        "react-native-url-polyfill": "^1.1.2"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+        }
+      }
+    },
+    "@wordpress/warning": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-1.3.1.tgz",
+      "integrity": "sha512-MdZ/4k2KmdH4h71KfKUXPCm8eR4fnD1t9W70vIX5+MsdiA7uplkwcDWxybITYVOmVT0Zk4F5CJ29AcsJAvtgZg=="
+    },
+    "@wp-g2/components": {
+      "version": "0.0.140",
+      "resolved": "https://registry.npmjs.org/@wp-g2/components/-/components-0.0.140.tgz",
+      "integrity": "sha512-bychuhZ3wPSB457CHYcogoPQPlP/eUA9GoTo0Fv0rj7f44Gr9XlPoqVT+GQa3CmPnvSCAl1sjoe75Vkaoo/O1w==",
+      "requires": {
+        "@popperjs/core": "^2.5.4",
+        "@wp-g2/context": "^0.0.140",
+        "@wp-g2/styles": "^0.0.140",
+        "@wp-g2/utils": "^0.0.140",
+        "csstype": "^3.0.3",
+        "downshift": "^6.0.15",
+        "framer-motion": "^2.1.0",
+        "highlight-words-core": "^1.2.2",
+        "history": "^4.9.0",
+        "lodash": "^4.17.19",
+        "path-to-regexp": "^1.7.0",
+        "react-colorful": "4.4.4",
+        "react-textarea-autosize": "^8.2.0",
+        "react-use-gesture": "^9.0.0",
+        "reakit": "1.1.0"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+        },
+        "reakit": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/reakit/-/reakit-1.1.0.tgz",
+          "integrity": "sha512-d/ERtwgBndBPsyPBPUl5jueyfFgsglIfQCnLMKuxM0PaWiIZ6Ys3XsYaNy/AaG8k46Ee5cQPMdRrR30nVcSToQ==",
+          "requires": {
+            "@popperjs/core": "^2.4.2",
+            "body-scroll-lock": "^3.0.2",
+            "reakit-system": "^0.13.0",
+            "reakit-utils": "^0.13.0",
+            "reakit-warning": "^0.4.0"
+          }
+        },
+        "reakit-utils": {
+          "version": "0.13.1",
+          "resolved": "https://registry.npmjs.org/reakit-utils/-/reakit-utils-0.13.1.tgz",
+          "integrity": "sha512-NBKgsot3tU91gZgK5MTInI/PR0T3kIsTmbU5MbGggSOcwU2dG/kbE8IrM2lC6ayCSL2W2QWkijT6kewdrIX7Gw=="
+        },
+        "reakit-warning": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/reakit-warning/-/reakit-warning-0.4.1.tgz",
+          "integrity": "sha512-AgnRN6cf8DYBF/mK2JEMFVL67Sbon8fDbFy1kfm0EDibtGsMOQtsFYfozZL7TwmJ4yg68VMhg8tmPHchVQRrlg==",
+          "requires": {
+            "reakit-utils": "^0.13.1"
+          }
+        }
+      }
+    },
+    "@wp-g2/context": {
+      "version": "0.0.140",
+      "resolved": "https://registry.npmjs.org/@wp-g2/context/-/context-0.0.140.tgz",
+      "integrity": "sha512-z32fxZ2tCVmYQC+wyyziyrhEvWBPFBQfUhUHF85JmTUPzQQeEPiLC3rgDAT0fUTFlJHinPJQq6871RDqFSwCUA==",
+      "requires": {
+        "@wp-g2/styles": "^0.0.140",
+        "@wp-g2/utils": "^0.0.140",
+        "lodash": "^4.17.19"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+        }
+      }
+    },
+    "@wp-g2/create-styles": {
+      "version": "0.0.140",
+      "resolved": "https://registry.npmjs.org/@wp-g2/create-styles/-/create-styles-0.0.140.tgz",
+      "integrity": "sha512-/60DxWjCAhsoYOqY7aiHVbkTAF+L6qZIyHyH50oNs9FTVkcRLHQFSC0kHgAam+Z9K3eImQ7hM52wfBDqae0q2Q==",
+      "requires": {
+        "@emotion/core": "^10.1.1",
+        "@emotion/is-prop-valid": "^0.8.8",
+        "@wp-g2/utils": "^0.0.140",
+        "create-emotion": "^10.0.27",
+        "emotion": "^10.0.27",
+        "emotion-theming": "^10.0.27",
+        "lodash": "^4.17.19",
+        "mitt": "^2.1.0",
+        "rtlcss": "^2.6.2",
+        "styled-griddie": "^0.1.3"
+      },
+      "dependencies": {
+        "@choojs/findup": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/@choojs/findup/-/findup-0.2.1.tgz",
+          "integrity": "sha512-YstAqNb0MCN8PjdLCDfRsBcGVRN41f3vgLvaI0IrIcBp4AqILRSS0DeWNGkicC+f/zRIPJLc+9RURVSepwvfBw==",
+          "requires": {
+            "commander": "^2.15.1"
+          }
+        },
+        "lodash": {
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+        },
+        "postcss": {
+          "version": "6.0.23",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+          "requires": {
+            "chalk": "^2.4.1",
+            "source-map": "^0.6.1",
+            "supports-color": "^5.4.0"
+          }
+        },
+        "rtlcss": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/rtlcss/-/rtlcss-2.6.2.tgz",
+          "integrity": "sha512-06LFAr+GAPo+BvaynsXRfoYTJvSaWRyOhURCQ7aeI1MKph9meM222F+Zkt3bDamyHHJuGi3VPtiRkpyswmQbGA==",
+          "requires": {
+            "@choojs/findup": "^0.2.1",
+            "chalk": "^2.4.2",
+            "mkdirp": "^0.5.1",
+            "postcss": "^6.0.23",
+            "strip-json-comments": "^2.0.0"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        }
+      }
+    },
+    "@wp-g2/styles": {
+      "version": "0.0.140",
+      "resolved": "https://registry.npmjs.org/@wp-g2/styles/-/styles-0.0.140.tgz",
+      "integrity": "sha512-wAvtqQOqX2zYpfEdVK4l4abH/hUUgw/+8+E5PvPgrsvqFg8IehNSksnjNF5/IloLRGAH70d8ytjMuMnUK8PVYA==",
+      "requires": {
+        "@wp-g2/create-styles": "^0.0.140",
+        "@wp-g2/utils": "^0.0.140"
+      }
+    },
+    "@wp-g2/utils": {
+      "version": "0.0.140",
+      "resolved": "https://registry.npmjs.org/@wp-g2/utils/-/utils-0.0.140.tgz",
+      "integrity": "sha512-a4uYi/XQEDrOAIO3JUQ+L/oeSkgp+08pSy41xxQ1nIRHs7X+Du84X2EFQrvZfGBRuXuVlVuUIlN2e0IE8yUZKw==",
+      "requires": {
+        "copy-to-clipboard": "^3.3.1",
+        "create-emotion": "^10.0.27",
+        "deepmerge": "^4.2.2",
+        "fast-deep-equal": "^3.1.3",
+        "hoist-non-react-statics": "^3.3.2",
+        "json2mq": "^0.2.0",
+        "lodash": "^4.17.19",
+        "memize": "^1.1.0",
+        "react-merge-refs": "^1.1.0",
+        "react-resize-aware": "^3.1.0",
+        "reakit-warning": "^0.5.5",
+        "tinycolor2": "^1.4.2",
+        "use-enhanced-state": "^0.0.13",
+        "use-isomorphic-layout-effect": "^1.0.0"
+      },
+      "dependencies": {
+        "fast-deep-equal": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+          "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+        },
+        "lodash": {
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+        }
       }
     },
     "@xtuc/ieee754": {
@@ -4250,7 +4884,8 @@
     "asap": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
+      "dev": true
     },
     "asn1": {
       "version": "0.2.4",
@@ -4419,6 +5054,23 @@
         "object.assign": "^4.1.0"
       }
     },
+    "babel-plugin-emotion": {
+      "version": "10.0.33",
+      "resolved": "https://registry.npmjs.org/babel-plugin-emotion/-/babel-plugin-emotion-10.0.33.tgz",
+      "integrity": "sha512-bxZbTTGz0AJQDHm8k6Rf3RQJ8tX2scsfsRyKVgAbiUPUNIRtlK+7JxP+TAd1kRLABFxe0CFm2VdK4ePkoA9FxQ==",
+      "requires": {
+        "@babel/helper-module-imports": "^7.0.0",
+        "@emotion/hash": "0.8.0",
+        "@emotion/memoize": "0.7.4",
+        "@emotion/serialize": "^0.11.16",
+        "babel-plugin-macros": "^2.0.0",
+        "babel-plugin-syntax-jsx": "^6.18.0",
+        "convert-source-map": "^1.5.0",
+        "escape-string-regexp": "^1.0.5",
+        "find-root": "^1.1.0",
+        "source-map": "^0.5.7"
+      }
+    },
     "babel-plugin-istanbul": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-5.2.0.tgz",
@@ -4439,6 +5091,74 @@
       "requires": {
         "@types/babel__traverse": "^7.0.6"
       }
+    },
+    "babel-plugin-macros": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.8.0.tgz",
+      "integrity": "sha512-SEP5kJpfGYqYKpBrj5XU3ahw5p5GOHJ0U5ssOSQ/WBVdwkD2Dzlce95exQTs3jOVWPPKLBN2rlEWkCK7dSmLvg==",
+      "requires": {
+        "@babel/runtime": "^7.7.2",
+        "cosmiconfig": "^6.0.0",
+        "resolve": "^1.12.0"
+      },
+      "dependencies": {
+        "cosmiconfig": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
+          "integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
+          "requires": {
+            "@types/parse-json": "^4.0.0",
+            "import-fresh": "^3.1.0",
+            "parse-json": "^5.0.0",
+            "path-type": "^4.0.0",
+            "yaml": "^1.7.2"
+          }
+        },
+        "import-fresh": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+          "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+          "requires": {
+            "parent-module": "^1.0.0",
+            "resolve-from": "^4.0.0"
+          }
+        },
+        "parse-json": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+          "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "error-ex": "^1.3.1",
+            "json-parse-even-better-errors": "^2.3.0",
+            "lines-and-columns": "^1.1.6"
+          }
+        },
+        "path-type": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+          "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
+        },
+        "resolve": {
+          "version": "1.19.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
+          "integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
+          "requires": {
+            "is-core-module": "^2.1.0",
+            "path-parse": "^1.0.6"
+          }
+        },
+        "resolve-from": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+          "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
+        }
+      }
+    },
+    "babel-plugin-syntax-jsx": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
+      "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
     },
     "babel-preset-jest": {
       "version": "24.9.0",
@@ -4557,6 +5277,11 @@
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
       "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
       "dev": true
+    },
+    "body-scroll-lock": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/body-scroll-lock/-/body-scroll-lock-3.1.5.tgz",
+      "integrity": "sha512-Yi1Xaml0EvNA0OYWxXiYNqY24AfWkbA6w5vxE7GWxtKfzIbZM+Qw+aSmkgsbWzbHiy/RCSkUZBplVxTA+E4jJg=="
     },
     "boolbase": {
       "version": "1.0.0",
@@ -4757,9 +5482,9 @@
       "dev": true
     },
     "cacache": {
-      "version": "11.3.3",
-      "resolved": "https://registry.npmjs.org/cacache/-/cacache-11.3.3.tgz",
-      "integrity": "sha512-p8WcneCytvzPxhDvYp31PD039vi77I12W+/KfR9S8AZbaiARFBCpsPJS+9uhWfeBfeAtW7o/4vt3MUqLkbY6nA==",
+      "version": "12.0.4",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-12.0.4.tgz",
+      "integrity": "sha512-a0tMB40oefvuInr4Cwb3GerbL9xTj1D5yg0T5xrjGCGyfvbxseIXX7BAO/u/hIXdafzOI5JC3wDwHyf24buOAQ==",
       "dev": true,
       "requires": {
         "bluebird": "^3.5.5",
@@ -4767,6 +5492,7 @@
         "figgy-pudding": "^3.5.1",
         "glob": "^7.1.4",
         "graceful-fs": "^4.1.15",
+        "infer-owner": "^1.0.3",
         "lru-cache": "^5.1.1",
         "mississippi": "^3.0.0",
         "mkdirp": "^0.5.1",
@@ -4850,6 +5576,11 @@
           "dev": true
         }
       }
+    },
+    "camelize": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.0.tgz",
+      "integrity": "sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs="
     },
     "caniuse-api": {
       "version": "3.0.0",
@@ -5021,9 +5752,9 @@
       "dev": true
     },
     "clipboard": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.4.tgz",
-      "integrity": "sha512-Vw26VSLRpJfBofiVaFb/I8PVfdI1OxKcYShe6fm0sP/DtmiWQNCjhM/okTvdCo0G+lMMm1rMYbk4IK4x1X+kgQ==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.6.tgz",
+      "integrity": "sha512-g5zbiixBRk/wyKakSwCKd7vQXDjFnAMGHoEyBogG/bw9kTD9GvdAvaoRR1ALcEzt3pVKxZR0pViekPMIS0QyGg==",
       "requires": {
         "good-listener": "^1.2.2",
         "select": "^1.1.2",
@@ -5098,9 +5829,9 @@
       }
     },
     "clsx": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.0.4.tgz",
-      "integrity": "sha512-1mQ557MIZTrL/140j+JVdRM6e31/OA4vTYxXgqIIZlndyfjHpyawKZia1Im05Vp9BWmImkcNrNtFYQMyFcgJDg=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.1.1.tgz",
+      "integrity": "sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA=="
     },
     "co": {
       "version": "4.6.0",
@@ -5186,8 +5917,7 @@
     "commander": {
       "version": "2.20.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
-      "dev": true
+      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ=="
     },
     "commondir": {
       "version": "1.0.1",
@@ -5200,6 +5930,11 @@
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
       "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
       "dev": true
+    },
+    "compute-scroll-into-view": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-1.0.16.tgz",
+      "integrity": "sha512-a85LHKY81oQnikatZYA90pufpZ6sQx++BoCxOEMsjpZx+ZnaKGQnCyCehTRr/1p9GBIAHTjcU9k71kSYWloLiQ=="
     },
     "concat-map": {
       "version": "0.0.1",
@@ -5244,16 +5979,10 @@
       "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=",
       "dev": true
     },
-    "convert-css-length": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/convert-css-length/-/convert-css-length-2.0.1.tgz",
-      "integrity": "sha512-iGpbcvhLPRKUbBc0Quxx7w/bV14AC3ItuBEGMahA5WTYqB8lq9jH0kTXFheCBASsYnqeMFZhiTruNxr1N59Axg=="
-    },
     "convert-source-map": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
       "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
-      "dev": true,
       "requires": {
         "safe-buffer": "~5.1.1"
       }
@@ -5278,10 +6007,13 @@
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
       "dev": true
     },
-    "core-js": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-      "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+    "copy-to-clipboard": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.1.tgz",
+      "integrity": "sha512-i13qo6kIHTTpCm8/Wup+0b1mVWETvu2kIMzKoK8FpkLkFxlt0znUAHcMzox+T8sPlqtZXq3CulEjQHsYiGFJUw==",
+      "requires": {
+        "toggle-selection": "^1.0.6"
+      }
     },
     "core-js-compat": {
       "version": "3.6.3",
@@ -5338,6 +6070,17 @@
       "requires": {
         "bn.js": "^4.1.0",
         "elliptic": "^6.0.0"
+      }
+    },
+    "create-emotion": {
+      "version": "10.0.27",
+      "resolved": "https://registry.npmjs.org/create-emotion/-/create-emotion-10.0.27.tgz",
+      "integrity": "sha512-fIK73w82HPPn/RsAij7+Zt8eCE8SptcJ3WoRMfxMtjteYxud8GDTKKld7MYwAX2TVhrw29uR1N/bVGxeStHILg==",
+      "requires": {
+        "@emotion/cache": "^10.0.27",
+        "@emotion/serialize": "^0.11.15",
+        "@emotion/sheet": "0.9.4",
+        "@emotion/utils": "0.11.3"
       }
     },
     "create-hash": {
@@ -5398,6 +6141,11 @@
         "randombytes": "^2.0.0",
         "randomfill": "^1.0.3"
       }
+    },
+    "css-color-keywords": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
+      "integrity": "sha1-/qJhbcZ2spYmhrOvjb2+GAskTgU="
     },
     "css-color-names": {
       "version": "0.0.4",
@@ -5460,6 +6208,23 @@
       "integrity": "sha512-jQVeeRG70QI08vSTwf1jHxp74JoZsr2XSgETae8/xC8ovSnL2WF87GTLO86Sbwdt2lK4Umg4HnnwMO4YF3Ce7w==",
       "dev": true
     },
+    "css-to-react-native": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-2.3.2.tgz",
+      "integrity": "sha512-VOFaeZA053BqvvvqIA8c9n0+9vFppVBAHCp6JgFTtTMU3Mzi+XnelJ9XC9ul3BqFzZyQ5N+H0SnwsWT2Ebchxw==",
+      "requires": {
+        "camelize": "^1.0.0",
+        "css-color-keywords": "^1.0.0",
+        "postcss-value-parser": "^3.3.0"
+      },
+      "dependencies": {
+        "postcss-value-parser": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+          "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ=="
+        }
+      }
+    },
     "css-tree": {
       "version": "1.0.0-alpha.37",
       "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.37.tgz",
@@ -5485,22 +6250,12 @@
       "dev": true
     },
     "css-vendor": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/css-vendor/-/css-vendor-2.0.7.tgz",
-      "integrity": "sha512-VS9Rjt79+p7M0WkPqcAza4Yq1ZHrsHrwf7hPL/bjQB+c1lwmAI+1FXxYTYt818D/50fFVflw0XKleiBN5RITkg==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/css-vendor/-/css-vendor-2.0.8.tgz",
+      "integrity": "sha512-x9Aq0XTInxrkuFeHKbYC7zWY8ai7qJ04Kxd9MnvbC1uO5DagxoHQjm4JvG+vCdXOoFtCjbL2XSZfxmoYa9uQVQ==",
       "requires": {
-        "@babel/runtime": "^7.6.2",
+        "@babel/runtime": "^7.8.3",
         "is-in-browser": "^1.0.2"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.8.3",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.3.tgz",
-          "integrity": "sha512-fVHx1rzEmwB130VTkLnxR+HmxcTjGzH12LYQcFFoBwakMd3aOMD4OsRN7tGG/UOYE2ektgFrS8uACAoRk1CY0w==",
-          "requires": {
-            "regenerator-runtime": "^0.13.2"
-          }
-        }
       }
     },
     "css-what": {
@@ -5617,9 +6372,9 @@
       }
     },
     "csstype": {
-      "version": "2.6.8",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.8.tgz",
-      "integrity": "sha512-msVS9qTuMT5zwAGCVm4mxfrZ18BNc6Csd0oJAtiFMZ1FAx1CCvy2+5MDmYoix63LM/6NDbNtodCiGYGmFgO0dA=="
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.6.tgz",
+      "integrity": "sha512-+ZAmfyWMT7TiIlzdqJgjMb7S4f1beorDbWbsocyK4RaiqA5RTX3K14bnBWmmA9QEM0gRdsjyyrEmcyga8Zsxmw=="
     },
     "currently-unhandled": {
       "version": "0.4.1",
@@ -5723,9 +6478,9 @@
       "dev": true
     },
     "deepmerge": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-1.5.2.tgz",
-      "integrity": "sha512-95k0GDqvBjZavkuvzx/YqVLv/6YYa17fz6ILMSf7neqQITCPbnfEnQvEgMPNjH4kgobe7+WIL0yJEHku+H3qtQ=="
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg=="
     },
     "define-properties": {
       "version": "1.1.3",
@@ -5861,9 +6616,9 @@
       }
     },
     "direction": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/direction/-/direction-1.0.3.tgz",
-      "integrity": "sha512-8bHRqMt4w/kND19KBksE4NOJo+gIOPuiZfxQvbd6xikfKbuNBYBdLIw0hA/4lWzBaDpwpW+Olmg1BjD9+0LU2w=="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/direction/-/direction-1.0.4.tgz",
+      "integrity": "sha512-GYqKi1aH7PJXxdhTeZBFrg8vUBeKXi+cNprXsC1kpJcbcVnV9wBsrOu1cQEdG0WeQwlfHiy3XvnKfIrJ2R0NzQ=="
     },
     "discontinuous-range": {
       "version": "1.0.0",
@@ -5881,30 +6636,20 @@
       }
     },
     "document.contains": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/document.contains/-/document.contains-1.0.1.tgz",
-      "integrity": "sha512-A1KqlZq1w605bwiiLqVZehWE9S9UYlUXPoduFWi64pNVNQ9vy6wwH/7BS+iEfSlF1YyZgcg5PZw5HqDi7FCrUw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/document.contains/-/document.contains-1.0.2.tgz",
+      "integrity": "sha512-YcvYFs15mX8m3AO1QNQy3BlIpSMfNRj3Ujk2BEJxsZG+HZf7/hZ6jr7mDpXrF8q+ff95Vef5yjhiZxm8CGJr6Q==",
       "requires": {
         "define-properties": "^1.1.3"
       }
     },
     "dom-helpers": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.1.3.tgz",
-      "integrity": "sha512-nZD1OtwfWGRBWlpANxacBEZrEuLa16o1nh7YopFWeoF68Zt8GGEmzHu6Xv4F3XaFIC+YXtTLrzgqKxFgLEe4jw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.0.tgz",
+      "integrity": "sha512-Ru5o9+V8CpunKnz5LGgWXkmrH/20cGKwcHwS4m73zIvs54CN9epEmT/HLqFJW3kXpakAFkEdzgy1hzlJe3E4OQ==",
       "requires": {
-        "@babel/runtime": "^7.6.3",
-        "csstype": "^2.6.7"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.8.3",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.3.tgz",
-          "integrity": "sha512-fVHx1rzEmwB130VTkLnxR+HmxcTjGzH12LYQcFFoBwakMd3aOMD4OsRN7tGG/UOYE2ektgFrS8uACAoRk1CY0w==",
-          "requires": {
-            "regenerator-runtime": "^0.13.2"
-          }
-        }
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
       }
     },
     "dom-scroll-into-view": {
@@ -5969,6 +6714,24 @@
       "dev": true,
       "requires": {
         "is-obj": "^1.0.0"
+      }
+    },
+    "downshift": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/downshift/-/downshift-6.1.0.tgz",
+      "integrity": "sha512-MnEJERij+1pTVAsOPsH3q9MJGNIZuu2sT90uxOCEOZYH6sEzkVGtUcTBVDRQkE8y96zpB7uEbRn24aE9VpHnZg==",
+      "requires": {
+        "@babel/runtime": "^7.12.5",
+        "compute-scroll-into-view": "^1.0.16",
+        "prop-types": "^15.7.2",
+        "react-is": "^17.0.1"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "17.0.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.1.tgz",
+          "integrity": "sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA=="
+        }
       }
     },
     "duplexify": {
@@ -6044,12 +6807,41 @@
       "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
       "dev": true
     },
-    "encoding": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+    "emotion": {
+      "version": "10.0.27",
+      "resolved": "https://registry.npmjs.org/emotion/-/emotion-10.0.27.tgz",
+      "integrity": "sha512-2xdDzdWWzue8R8lu4G76uWX5WhyQuzATon9LmNeCy/2BHVC6dsEpfhN1a0qhELgtDVdjyEA6J8Y/VlI5ZnaH0g==",
       "requires": {
-        "iconv-lite": "~0.4.13"
+        "babel-plugin-emotion": "^10.0.27",
+        "create-emotion": "^10.0.27"
+      }
+    },
+    "emotion-theming": {
+      "version": "10.0.27",
+      "resolved": "https://registry.npmjs.org/emotion-theming/-/emotion-theming-10.0.27.tgz",
+      "integrity": "sha512-MlF1yu/gYh8u+sLUqA0YuA9JX0P4Hb69WlKc/9OLo+WCXuX6sy/KoIa+qJimgmr2dWqnypYKYPX37esjDBbhdw==",
+      "requires": {
+        "@babel/runtime": "^7.5.5",
+        "@emotion/weak-memoize": "0.2.5",
+        "hoist-non-react-statics": "^3.3.0"
+      }
+    },
+    "encoding": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "requires": {
+        "iconv-lite": "^0.6.2"
+      },
+      "dependencies": {
+        "iconv-lite": {
+          "version": "0.6.2",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.2.tgz",
+          "integrity": "sha512-2y91h5OpQlolefMPmUlivelittSWy0rP+oYVpn6A7GwVHNE8AWzoYOBNmlwks3LobaJxgHCYZAnyNo2GgpNRNQ==",
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3.0.0"
+          }
+        }
       }
     },
     "end-of-stream": {
@@ -6440,8 +7232,7 @@
     "esutils": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
-      "dev": true
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
     },
     "events": {
       "version": "3.0.0",
@@ -6671,6 +7462,11 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "fast-memoize": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/fast-memoize/-/fast-memoize-2.5.2.tgz",
+      "integrity": "sha512-Ue0LwpDYErFbmNnZSF0UH6eImUwDmogUO1jyE+JbN2gsQz/jICm1Ve7t9QT0rNSsfJt+Hs4/S3GnsDVjL4HVrw=="
+    },
     "fb-watchman": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.1.tgz",
@@ -6678,20 +7474,6 @@
       "dev": true,
       "requires": {
         "bser": "2.1.1"
-      }
-    },
-    "fbjs": {
-      "version": "0.8.17",
-      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
-      "integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
-      "requires": {
-        "core-js": "^1.0.0",
-        "isomorphic-fetch": "^2.1.1",
-        "loose-envify": "^1.0.0",
-        "object-assign": "^4.1.0",
-        "promise": "^7.1.1",
-        "setimmediate": "^1.0.5",
-        "ua-parser-js": "^0.7.18"
       }
     },
     "figgy-pudding": {
@@ -6789,8 +7571,7 @@
     "find-root": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
-      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
-      "dev": true
+      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng=="
     },
     "find-up": {
       "version": "3.0.0",
@@ -6894,6 +7675,27 @@
       "dev": true,
       "requires": {
         "map-cache": "^0.2.2"
+      }
+    },
+    "framer-motion": {
+      "version": "2.9.5",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-2.9.5.tgz",
+      "integrity": "sha512-epSX4Co1YbDv0mjfHouuY0q361TpHE7WQzCp/xMTilxy4kXd+Z23uJzPVorfzbm1a/9q1Yu8T5bndaw65NI4Tg==",
+      "requires": {
+        "@emotion/is-prop-valid": "^0.8.2",
+        "framesync": "^4.1.0",
+        "hey-listen": "^1.0.8",
+        "popmotion": "9.0.0-rc.20",
+        "style-value-types": "^3.1.9",
+        "tslib": "^1.10.0"
+      }
+    },
+    "framesync": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/framesync/-/framesync-4.1.0.tgz",
+      "integrity": "sha512-MmgZ4wCoeVxNbx2xp5hN/zPDCbLSKiDt4BbbslK7j/pM2lg5S0vhTNv1v8BCVb99JPIo6hXBFdwzU7Q4qcAaoQ==",
+      "requires": {
+        "hey-listen": "^1.0.5"
       }
     },
     "from2": {
@@ -7658,6 +8460,12 @@
         "globule": "^1.0.0"
       }
     },
+    "gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true
+    },
     "get-caller-file": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
@@ -7834,10 +8642,10 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.0.tgz",
       "integrity": "sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg=="
     },
-    "gud": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/gud/-/gud-1.0.0.tgz",
-      "integrity": "sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw=="
+    "gradient-parser": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/gradient-parser/-/gradient-parser-0.1.5.tgz",
+      "integrity": "sha1-DH4heVWeXOfY1x9EI6+TcQCyJIw="
     },
     "har-schema": {
       "version": "2.0.0",
@@ -7946,6 +8754,16 @@
       "integrity": "sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==",
       "dev": true
     },
+    "hey-listen": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/hey-listen/-/hey-listen-1.0.8.tgz",
+      "integrity": "sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q=="
+    },
+    "highlight-words-core": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/highlight-words-core/-/highlight-words-core-1.2.2.tgz",
+      "integrity": "sha512-BXUKIkUuh6cmmxzi5OIbUJxrG8OAk2MqoL1DtO3Wo9D2faJg2ph5ntyuQeLqaHJmzER6H5tllCDA9ZnNe9BVGg=="
+    },
     "history": {
       "version": "4.10.1",
       "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
@@ -7971,9 +8789,9 @@
       }
     },
     "hoist-non-react-statics": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
-      "integrity": "sha512-wbg3bpgA/ZqWrZuMOeJi8+SKMhr7X9TesL/rXMjTzh0p0JUBo3II8DHboYbuIXWRlttrUFxwcu/5kygrCw8fJw==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
       "requires": {
         "react-is": "^16.7.0"
       }
@@ -8079,14 +8897,15 @@
       "dev": true
     },
     "hyphenate-style-name": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.3.tgz",
-      "integrity": "sha512-EcuixamT82oplpoJ2XU4pDtKGWQ7b00CD9f1ug9IaQ3p1bkHMiKCZ9ut9QDI6qsa6cpUuB+A/I+zLtdNK4n2DQ=="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz",
+      "integrity": "sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ=="
     },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
@@ -8109,8 +8928,7 @@
     "ieee754": {
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
-      "dev": true
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
     },
     "iferr": {
       "version": "0.1.5",
@@ -8173,6 +8991,14 @@
       "resolved": "https://registry.npmjs.org/in-publish/-/in-publish-2.0.0.tgz",
       "integrity": "sha1-4g/146KvwmkDILbcVSaCqcf631E=",
       "dev": true
+    },
+    "indefinite-observable": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/indefinite-observable/-/indefinite-observable-2.0.1.tgz",
+      "integrity": "sha512-G8vgmork+6H9S8lUAg1gtXEj2JxIQTo0g2PbFiYOdjkziSI0F7UYBiVwhZRuixhBCNGczAls34+5HJPyZysvxQ==",
+      "requires": {
+        "symbol-observable": "1.2.0"
+      }
     },
     "indent-string": {
       "version": "2.1.0",
@@ -8391,6 +9217,14 @@
         "rgba-regex": "^1.0.0"
       }
     },
+    "is-core-module": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
+      "integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
+      "requires": {
+        "has": "^1.0.3"
+      }
+    },
     "is-data-descriptor": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
@@ -8565,7 +9399,8 @@
     "is-promise": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
-      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+      "dev": true
     },
     "is-regex": {
       "version": "1.0.4",
@@ -8584,7 +9419,8 @@
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true
     },
     "is-string": {
       "version": "1.0.5",
@@ -8660,15 +9496,6 @@
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
-    },
-    "isomorphic-fetch": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
-      "requires": {
-        "node-fetch": "^1.0.1",
-        "whatwg-fetch": ">=0.10.0"
-      }
     },
     "isstream": {
       "version": "0.1.2",
@@ -9181,6 +10008,11 @@
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
       "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
     },
+    "json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
+    },
     "json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
@@ -9204,6 +10036,14 @@
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
+    },
+    "json2mq": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/json2mq/-/json2mq-0.2.0.tgz",
+      "integrity": "sha1-tje9O6nqvhIsg+lyBIOusQ0skEo=",
+      "requires": {
+        "string-convert": "^0.2.0"
+      }
     },
     "json2php": {
       "version": "0.0.4",
@@ -9233,80 +10073,82 @@
       }
     },
     "jss": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/jss/-/jss-10.0.3.tgz",
-      "integrity": "sha512-AcDvFdOk16If9qvC9KN3oFXsrkHWM9+TaPMpVB9orm3z+nq1Xw3ofHyflRe/mkSucRZnaQtlhZs1hdP3DR9uRw==",
+      "version": "10.5.1",
+      "resolved": "https://registry.npmjs.org/jss/-/jss-10.5.1.tgz",
+      "integrity": "sha512-hbbO3+FOTqVdd7ZUoTiwpHzKXIo5vGpMNbuXH1a0wubRSWLWSBvwvaq4CiHH/U42CmjOnp6lVNNs/l+Z7ZdDmg==",
       "requires": {
         "@babel/runtime": "^7.3.1",
-        "csstype": "^2.6.5",
+        "csstype": "^3.0.2",
+        "indefinite-observable": "^2.0.1",
         "is-in-browser": "^1.1.3",
         "tiny-warning": "^1.0.2"
       }
     },
     "jss-plugin-camel-case": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/jss-plugin-camel-case/-/jss-plugin-camel-case-10.0.3.tgz",
-      "integrity": "sha512-rild/oFKFkmRP7AoiX9D6bdDAUfmJv8c7sEBvFoi+JP31dn2W8nw4txMKGnV1LJKlFkYprdZt1X99Uvztl1hug==",
+      "version": "10.5.1",
+      "resolved": "https://registry.npmjs.org/jss-plugin-camel-case/-/jss-plugin-camel-case-10.5.1.tgz",
+      "integrity": "sha512-9+oymA7wPtswm+zxVti1qiowC5q7bRdCJNORtns2JUj/QHp2QPXYwSNRD8+D2Cy3/CEMtdJzlNnt5aXmpS6NAg==",
       "requires": {
         "@babel/runtime": "^7.3.1",
         "hyphenate-style-name": "^1.0.3",
-        "jss": "^10.0.3"
+        "jss": "10.5.1"
       }
     },
     "jss-plugin-default-unit": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/jss-plugin-default-unit/-/jss-plugin-default-unit-10.0.3.tgz",
-      "integrity": "sha512-n+XfVLPF9Qh7IOTdQ8M4oRpjpg6egjr/r0NNytubbCafMgCILJYIVrMTGgOTydH+uvak8onQY3f/F9hasPUx6g==",
+      "version": "10.5.1",
+      "resolved": "https://registry.npmjs.org/jss-plugin-default-unit/-/jss-plugin-default-unit-10.5.1.tgz",
+      "integrity": "sha512-D48hJBc9Tj3PusvlillHW8Fz0y/QqA7MNmTYDQaSB/7mTrCZjt7AVRROExoOHEtd2qIYKOYJW3Jc2agnvsXRlQ==",
       "requires": {
         "@babel/runtime": "^7.3.1",
-        "jss": "^10.0.3"
+        "jss": "10.5.1"
       }
     },
     "jss-plugin-global": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/jss-plugin-global/-/jss-plugin-global-10.0.3.tgz",
-      "integrity": "sha512-kNotkAciJIXpIGYnmueaIifBne9rdq31O8Xq1nF7KMfKlskNRANTcEX5rVnsGKl2yubTMYfjKBFCeDgcQn6+gA==",
+      "version": "10.5.1",
+      "resolved": "https://registry.npmjs.org/jss-plugin-global/-/jss-plugin-global-10.5.1.tgz",
+      "integrity": "sha512-jX4XpNgoaB8yPWw/gA1aPXJEoX0LNpvsROPvxlnYe+SE0JOhuvF7mA6dCkgpXBxfTWKJsno7cDSCgzHTocRjCQ==",
       "requires": {
         "@babel/runtime": "^7.3.1",
-        "jss": "^10.0.3"
+        "jss": "10.5.1"
       }
     },
     "jss-plugin-nested": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/jss-plugin-nested/-/jss-plugin-nested-10.0.3.tgz",
-      "integrity": "sha512-OMucRs9YLvWlZ3Ew+VhdgNVMwSS2zZy/2vy+s/etvopnPUzDHgCnJwdY2Wx/SlhLGERJeKKufyih2seH+ui0iw==",
+      "version": "10.5.1",
+      "resolved": "https://registry.npmjs.org/jss-plugin-nested/-/jss-plugin-nested-10.5.1.tgz",
+      "integrity": "sha512-xXkWKOCljuwHNjSYcXrCxBnjd8eJp90KVFW1rlhvKKRXnEKVD6vdKXYezk2a89uKAHckSvBvBoDGsfZrldWqqQ==",
       "requires": {
         "@babel/runtime": "^7.3.1",
-        "jss": "^10.0.3",
+        "jss": "10.5.1",
         "tiny-warning": "^1.0.2"
       }
     },
     "jss-plugin-props-sort": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/jss-plugin-props-sort/-/jss-plugin-props-sort-10.0.3.tgz",
-      "integrity": "sha512-ufhvdCMnRcDa0tNHoZ12OcVNQQyE10yLMohxo/UIMarLV245rM6n9D19A12epjldRgyiS13SoSyLFCJEobprYg==",
+      "version": "10.5.1",
+      "resolved": "https://registry.npmjs.org/jss-plugin-props-sort/-/jss-plugin-props-sort-10.5.1.tgz",
+      "integrity": "sha512-t+2vcevNmMg4U/jAuxlfjKt46D/jHzCPEjsjLRj/J56CvP7Iy03scsUP58Iw8mVnaV36xAUZH2CmAmAdo8994g==",
       "requires": {
         "@babel/runtime": "^7.3.1",
-        "jss": "^10.0.3"
+        "jss": "10.5.1"
       }
     },
     "jss-plugin-rule-value-function": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/jss-plugin-rule-value-function/-/jss-plugin-rule-value-function-10.0.3.tgz",
-      "integrity": "sha512-RWwIT2UBAIwf3f6DQtt5gyjxHMRJoeO9TQku+ueR8dBMakqSSe8vFwQNfjXEoe0W+Tez5HZCTkZKNMulv3Z+9A==",
+      "version": "10.5.1",
+      "resolved": "https://registry.npmjs.org/jss-plugin-rule-value-function/-/jss-plugin-rule-value-function-10.5.1.tgz",
+      "integrity": "sha512-3gjrSxsy4ka/lGQsTDY8oYYtkt2esBvQiceGBB4PykXxHoGRz14tbCK31Zc6DHEnIeqsjMUGbq+wEly5UViStQ==",
       "requires": {
         "@babel/runtime": "^7.3.1",
-        "jss": "^10.0.3"
+        "jss": "10.5.1",
+        "tiny-warning": "^1.0.2"
       }
     },
     "jss-plugin-vendor-prefixer": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/jss-plugin-vendor-prefixer/-/jss-plugin-vendor-prefixer-10.0.3.tgz",
-      "integrity": "sha512-zVs6e5z4tFRK/fJ5kuTLzXlTFQbLeFTVwk7lTZiYNufmZwKT0kSmnOJDUukcSe7JLGSRztjWhnHB/6voP174gw==",
+      "version": "10.5.1",
+      "resolved": "https://registry.npmjs.org/jss-plugin-vendor-prefixer/-/jss-plugin-vendor-prefixer-10.5.1.tgz",
+      "integrity": "sha512-cLkH6RaPZWHa1TqSfd2vszNNgxT1W0omlSjAd6hCFHp3KIocSrW21gaHjlMU26JpTHwkc+tJTCQOmE/O1A4FKQ==",
       "requires": {
         "@babel/runtime": "^7.3.1",
-        "css-vendor": "^2.0.7",
-        "jss": "^10.0.3"
+        "css-vendor": "^2.0.8",
+        "jss": "10.5.1"
       }
     },
     "junk": {
@@ -9351,6 +10193,11 @@
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2"
       }
+    },
+    "lines-and-columns": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
+      "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA="
     },
     "load-json-file": {
       "version": "4.0.0",
@@ -9621,9 +10468,9 @@
       }
     },
     "memize": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/memize/-/memize-1.0.5.tgz",
-      "integrity": "sha512-Dm8Jhb5kiC4+ynYsVR4QDXKt+o2dfqGuY4hE2x+XlXZkdndlT80bJxfcMv5QGp/FCy6MhG7f5ElpmKPFKOSEpg=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/memize/-/memize-1.1.0.tgz",
+      "integrity": "sha512-K4FcPETOMTwe7KL2LK0orMhpOmWD2wRGwWWpbZy0fyArwsyIKR8YJVz8+efBAh3BO4zPqlSICu4vsLTRRqtFAg=="
     },
     "memory-fs": {
       "version": "0.4.1",
@@ -9807,13 +10654,12 @@
       "dev": true
     },
     "mini-create-react-context": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/mini-create-react-context/-/mini-create-react-context-0.3.2.tgz",
-      "integrity": "sha512-2v+OeetEyliMt5VHMXsBhABoJ0/M4RCe7fatd/fBy6SMiKazUSEt3gxxypfnk2SHMkdBYvorHRoQxuGoiwbzAw==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/mini-create-react-context/-/mini-create-react-context-0.4.1.tgz",
+      "integrity": "sha512-YWCYEmd5CQeHGSAKrYvXgmzzkrvssZcuuQDDeqkT+PziKGMgE+0MCCtcKbROzocGBG1meBLl2FotlRwf4gAzbQ==",
       "requires": {
-        "@babel/runtime": "^7.4.0",
-        "gud": "^1.0.0",
-        "tiny-warning": "^1.0.2"
+        "@babel/runtime": "^7.12.1",
+        "tiny-warning": "^1.0.3"
       }
     },
     "minimalistic-assert": {
@@ -9904,6 +10750,11 @@
         "through2": "^2.0.0"
       }
     },
+    "mitt": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-2.1.0.tgz",
+      "integrity": "sha512-ILj2TpLiysu2wkBbWjAmww7TkZb65aiQO+DkVdUTBpBXq+MHYiETENkKFMtsJZX1Lf4pe4QOrTSjIfUwN5lRdg=="
+    },
     "mixin-deep": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
@@ -9929,7 +10780,6 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       },
@@ -9937,15 +10787,22 @@
         "minimist": {
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         }
       }
     },
     "moment": {
-      "version": "2.24.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
-      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
+    },
+    "moment-timezone": {
+      "version": "0.5.32",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.32.tgz",
+      "integrity": "sha512-Z8QNyuQHQAmWucp8Knmgei8YNo28aLjJq6Ma+jy1ZSpSk5nyfRT8xgUbSQvD2+2UajISfenndwvFuH3NGS+nvA==",
+      "requires": {
+        "moment": ">= 2.9.0"
+      }
     },
     "moo": {
       "version": "0.4.3",
@@ -9954,9 +10811,9 @@
       "dev": true
     },
     "mousetrap": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/mousetrap/-/mousetrap-1.6.3.tgz",
-      "integrity": "sha512-bd+nzwhhs9ifsUrC2tWaSgm24/oo2c83zaRyZQF06hYA6sANfsXHtnZ19AbbbDXCDzeH5nZBSQ4NvCjgD62tJA=="
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/mousetrap/-/mousetrap-1.6.5.tgz",
+      "integrity": "sha512-QNo4kEepaIBwiT8CDhP98umTetp+JNfQYBWvC1pc6/OAibuXtRcxZ58Qz8skvEHYvURne/7R8T5VoOI7rDsEUA=="
     },
     "move-concurrently": {
       "version": "1.0.1",
@@ -10035,31 +10892,83 @@
       "dev": true
     },
     "newspack-components": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/newspack-components/-/newspack-components-1.0.3.tgz",
-      "integrity": "sha512-DCGGs+xP5EzaRzFbxv9gF5CMMTmlfQp3D9SdZWB/KkqkeOvN7kJ/22D7gubAtQ+o50MtNJvRta1cDCowwk2EYw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/newspack-components/-/newspack-components-1.4.0.tgz",
+      "integrity": "sha512-zDbPICE3PdqJFyeW9JfmrNx7rXYVra2V6n/X5uYW/ZVF9JQ7GpG8LxgS6J8HgSeMAhBfCOVbDgOEaGoCjJBXow==",
       "requires": {
         "@material-ui/core": "^4.8.2",
         "@material-ui/icons": "^4.5.1",
         "@wordpress/base-styles": "^1.0.0",
         "@wordpress/components": "^7.3.1",
         "@wordpress/element": "^2.3.0",
+        "@wordpress/i18n": "^3.11.0",
+        "classnames": "^2.2.6",
+        "lodash": "^4.17.20",
         "react-router-dom": "^5.0.1"
+      },
+      "dependencies": {
+        "@wordpress/base-styles": {
+          "version": "1.11.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-1.11.0.tgz",
+          "integrity": "sha512-CV7NsA0SzLGKFmhhTIhi6pWeijeSaBl16hwp+x7OcyQKy/MMbVx2gXsHf3KjGNY18FT1Uf2MlhcdIeBM22RpWQ=="
+        },
+        "@wordpress/components": {
+          "version": "7.4.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-7.4.0.tgz",
+          "integrity": "sha512-riVey0Z5835YdPZLWFSAs/4Hzo0nr7WA/393mRXwGuUtkqdk7ia++5emKfhyaCLYbinVBd6366xFFfiFxxcsCA==",
+          "requires": {
+            "@babel/runtime": "^7.4.4",
+            "@wordpress/a11y": "^2.3.0",
+            "@wordpress/api-fetch": "^3.2.0",
+            "@wordpress/compose": "^3.3.0",
+            "@wordpress/dom": "^2.3.0",
+            "@wordpress/element": "^2.4.0",
+            "@wordpress/hooks": "^2.3.0",
+            "@wordpress/i18n": "^3.4.0",
+            "@wordpress/is-shallow-equal": "^1.3.0",
+            "@wordpress/keycodes": "^2.3.0",
+            "@wordpress/rich-text": "^3.3.0",
+            "@wordpress/url": "^2.6.0",
+            "classnames": "^2.2.5",
+            "clipboard": "^2.0.1",
+            "diff": "^3.5.0",
+            "dom-scroll-into-view": "^1.2.1",
+            "lodash": "^4.17.11",
+            "memize": "^1.0.5",
+            "moment": "^2.22.1",
+            "mousetrap": "^1.6.2",
+            "re-resizable": "^4.7.1",
+            "react-click-outside": "^3.0.0",
+            "react-dates": "^17.1.1",
+            "rememo": "^3.0.0",
+            "tinycolor2": "^1.4.1",
+            "uuid": "^3.3.2"
+          }
+        },
+        "@wordpress/is-shallow-equal": {
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-1.8.0.tgz",
+          "integrity": "sha512-OV3qJqP9LhjuOzt85TsyBwv+//CvC8Byf/81D3NmjPKlstLaD/bBCC5nBhH6dKAv4bShYtQ2Hmut+V4dZnOM1A==",
+          "requires": {
+            "@babel/runtime": "^7.8.3"
+          }
+        },
+        "lodash": {
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+        },
+        "re-resizable": {
+          "version": "4.11.0",
+          "resolved": "https://registry.npmjs.org/re-resizable/-/re-resizable-4.11.0.tgz",
+          "integrity": "sha512-dye+7rERqNf/6mDT1iwps+4Gf42420xuZgygF33uX178DxffqcyeuHbBuJ382FIcB5iP6mMZOhfW7kI0uXwb/Q=="
+        }
       }
     },
     "nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
-    },
-    "node-fetch": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-      "requires": {
-        "encoding": "^0.1.11",
-        "is-stream": "^1.0.1"
-      }
     },
     "node-gyp": {
       "version": "3.8.0",
@@ -10272,11 +11181,6 @@
       "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
       "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=",
       "dev": true
-    },
-    "normalize-scroll-left": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/normalize-scroll-left/-/normalize-scroll-left-0.2.0.tgz",
-      "integrity": "sha512-t5oCENZJl8TGusJKoCJm7+asaSsPuNmK6+iEjrZ5TyBj2f02brCRsd4c83hwtu+e5d4LCSBZ0uoDlMjBo+A8yA=="
     },
     "normalize-url": {
       "version": "1.9.1",
@@ -10915,7 +11819,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-      "dev": true,
       "requires": {
         "callsites": "^3.0.0"
       },
@@ -10923,8 +11826,7 @@
         "callsites": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-          "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-          "dev": true
+          "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="
         }
       }
     },
@@ -11058,17 +11960,18 @@
         "sha.js": "^2.4.8"
       }
     },
-    "pegjs": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/pegjs/-/pegjs-0.10.0.tgz",
-      "integrity": "sha1-z4uvrm7d/0tafvsYUmnqr0YQ3b0=",
-      "dev": true
-    },
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
       "dev": true
+    },
+    "picomatch": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
+      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
+      "dev": true,
+      "optional": true
     },
     "pidtree": {
       "version": "0.3.0",
@@ -11120,10 +12023,21 @@
       "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
       "dev": true
     },
+    "popmotion": {
+      "version": "9.0.0-rc.20",
+      "resolved": "https://registry.npmjs.org/popmotion/-/popmotion-9.0.0-rc.20.tgz",
+      "integrity": "sha512-f98sny03WuA+c8ckBjNNXotJD4G2utG/I3Q23NU69OEafrXtxxSukAaJBxzbtxwDvz3vtZK69pu9ojdkMoBNTg==",
+      "requires": {
+        "framesync": "^4.1.0",
+        "hey-listen": "^1.0.8",
+        "style-value-types": "^3.1.9",
+        "tslib": "^1.10.0"
+      }
+    },
     "popper.js": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.0.tgz",
-      "integrity": "sha512-+G+EkOPoE5S/zChTpmBSSDYmhXJ5PsW8eMhH8cP/CQHMFPBG/kC9Y5IIw6qNYgdJ+/COf0ddY2li28iHaZRSjw=="
+      "version": "1.16.1-lts",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1-lts.tgz",
+      "integrity": "sha512-Kjw8nKRl1m+VrSFCoVGPph93W/qrSO7ZkqPpTf7F4bk/sqcfWK019dWBUpE/fBOsOQY1dks/Bmcbfn1heM/IsA=="
     },
     "posix-character-classes": {
       "version": "0.1.1",
@@ -11827,6 +12741,7 @@
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
       "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "dev": true,
       "requires": {
         "asap": "~2.0.3"
       }
@@ -11925,8 +12840,7 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "q": {
       "version": "1.5.1",
@@ -11937,12 +12851,13 @@
     "qs": {
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+      "dev": true
     },
     "query-string": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.9.0.tgz",
-      "integrity": "sha512-KG4bhCFYapExLsUHrFt+kQVEegF2agm4cpF/VNc6pZVthIfCc/GK8t8VyNIE3nyXG9DK3Tf2EGkxjR6/uRdYsA==",
+      "version": "6.13.8",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.13.8.tgz",
+      "integrity": "sha512-jxJzQI2edQPE/NPUOusNjO/ZOGqr1o2OBa/3M00fU76FsLXDVbJDv/p7ng5OdQyorKrkRz1oqfwmbe5MAMePQg==",
       "requires": {
         "decode-uri-component": "^0.2.0",
         "split-on-first": "^1.0.0",
@@ -12006,27 +12921,28 @@
       }
     },
     "re-resizable": {
-      "version": "4.11.0",
-      "resolved": "https://registry.npmjs.org/re-resizable/-/re-resizable-4.11.0.tgz",
-      "integrity": "sha512-dye+7rERqNf/6mDT1iwps+4Gf42420xuZgygF33uX178DxffqcyeuHbBuJ382FIcB5iP6mMZOhfW7kI0uXwb/Q=="
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/re-resizable/-/re-resizable-6.9.0.tgz",
+      "integrity": "sha512-3cUDG81ylyqI0Pdgle/RHwwRYq0ORZzsUaySOCO8IbEtNyaRtrIHYm/jMQ5pjcNiKCxR3vsSymIQZHwJq4gg2Q==",
+      "requires": {
+        "fast-memoize": "^2.5.1"
+      }
     },
     "react": {
-      "version": "16.8.6",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.8.6.tgz",
-      "integrity": "sha512-pC0uMkhLaHm11ZSJULfOBqV4tIZkx87ZLvbbQYunNixAAvjnC+snJCg0XQXn9VIsttVsbZP/H/ewzgsd5fxKXw==",
+      "version": "16.14.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
+      "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2",
-        "scheduler": "^0.13.6"
+        "prop-types": "^15.6.2"
       }
     },
     "react-addons-shallow-compare": {
-      "version": "15.6.2",
-      "resolved": "https://registry.npmjs.org/react-addons-shallow-compare/-/react-addons-shallow-compare-15.6.2.tgz",
-      "integrity": "sha1-GYoAuR/DdiPbZKKP0XtZa6NicC8=",
+      "version": "15.6.3",
+      "resolved": "https://registry.npmjs.org/react-addons-shallow-compare/-/react-addons-shallow-compare-15.6.3.tgz",
+      "integrity": "sha512-EDJbgKTtGRLhr3wiGDXK/+AEJ59yqGS+tKE6mue0aNXT6ZMR7VJbbzIiT6akotmHg1BLj46ElJSb+NBMp80XBg==",
       "requires": {
-        "fbjs": "^0.8.4",
         "object-assign": "^4.1.0"
       }
     },
@@ -12044,6 +12960,11 @@
           "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
         }
       }
+    },
+    "react-colorful": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-4.4.4.tgz",
+      "integrity": "sha512-01V2/6rr6sa1vaZntWZJXZxnU7ew02NG2rqq0eoVp4d3gFU5Ug9lDzNMbr+8ns0byXsJbBR8LbwQTlAjz6x7Kg=="
     },
     "react-dates": {
       "version": "17.2.0",
@@ -12066,14 +12987,14 @@
       }
     },
     "react-dom": {
-      "version": "16.8.6",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.8.6.tgz",
-      "integrity": "sha512-1nL7PIq9LTL3fthPqwkvr2zY7phIPjYrT0jp4HjyEQrEROnw4dG41VVwi/wfoCneoleqrNX7iAD+pXebJZwrwA==",
+      "version": "16.14.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
+      "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2",
-        "scheduler": "^0.13.6"
+        "scheduler": "^0.19.1"
       }
     },
     "react-is": {
@@ -12081,12 +13002,25 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
       "integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA=="
     },
+    "react-merge-refs": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/react-merge-refs/-/react-merge-refs-1.1.0.tgz",
+      "integrity": "sha512-alTKsjEL0dKH/ru1Iyn7vliS2QRcBp9zZPGoWxUOvRGWPUYgjo+V01is7p04It6KhgrzhJGnIj9GgX8W4bZoCQ=="
+    },
     "react-moment-proptypes": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/react-moment-proptypes/-/react-moment-proptypes-1.7.0.tgz",
       "integrity": "sha512-ZbOn/P4u469WEGAw5hgkS/E+g1YZqdves2BjYsLluJobzUZCtManhjHiZKjniBVT7MSHM6D/iKtRVzlXVv3ikA==",
       "requires": {
         "moment": ">=1.6.0"
+      }
+    },
+    "react-native-url-polyfill": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/react-native-url-polyfill/-/react-native-url-polyfill-1.2.0.tgz",
+      "integrity": "sha512-hpLZ8RyS3oGVyTOe/HjoqVoCOSkeJvrCoEB3bJsY7t9uh7kpQDV6kgvdlECEafYpxe3RzMrKLVcmWRbPU7CuAw==",
+      "requires": {
+        "whatwg-url-without-unicode": "8.0.0-3"
       }
     },
     "react-outside-click-handler": {
@@ -12102,23 +13036,28 @@
       }
     },
     "react-portal": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/react-portal/-/react-portal-4.2.0.tgz",
-      "integrity": "sha512-Zf+vGQ/VEAb5XAy+muKEn48yhdCNYPZaB1BWg1xc8sAZWD8pXTgPtQT4ihBdmWzsfCq8p8/kqf0GWydSBqc+Eg==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/react-portal/-/react-portal-4.2.1.tgz",
+      "integrity": "sha512-fE9kOBagwmTXZ3YGRYb4gcMy+kSA+yLO0xnPankjRlfBv4uCpFXqKPfkpsGQQR15wkZ9EssnvTOl1yMzbkxhPQ==",
       "requires": {
         "prop-types": "^15.5.8"
       }
     },
+    "react-resize-aware": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/react-resize-aware/-/react-resize-aware-3.1.0.tgz",
+      "integrity": "sha512-bIhHlxVTX7xKUz14ksXMEHjzCZPTpQZKZISY3nbTD273pDKPABGFNFBP6Tr42KECxzC5YQiKpMchjTVJCqaxpA=="
+    },
     "react-router": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.1.2.tgz",
-      "integrity": "sha512-yjEuMFy1ONK246B+rsa0cUam5OeAQ8pyclRDgpxuSCrAlJ1qN9uZ5IgyKC7gQg0w8OM50NXHEegPh/ks9YuR2A==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.2.0.tgz",
+      "integrity": "sha512-smz1DUuFHRKdcJC0jobGo8cVbhO3x50tCL4icacOlcwDOEQPq4TMqwx3sY1TP+DvtTgz4nm3thuo7A+BK2U0Dw==",
       "requires": {
         "@babel/runtime": "^7.1.2",
         "history": "^4.9.0",
         "hoist-non-react-statics": "^3.1.0",
         "loose-envify": "^1.3.1",
-        "mini-create-react-context": "^0.3.0",
+        "mini-create-react-context": "^0.4.0",
         "path-to-regexp": "^1.7.0",
         "prop-types": "^15.6.2",
         "react-is": "^16.6.0",
@@ -12127,17 +13066,26 @@
       }
     },
     "react-router-dom": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.1.2.tgz",
-      "integrity": "sha512-7BPHAaIwWpZS074UKaw1FjVdZBSVWEk8IuDXdB+OkLb8vd/WRQIpA4ag9WQk61aEfQs47wHyjWUoUGGZxpQXew==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.2.0.tgz",
+      "integrity": "sha512-gxAmfylo2QUjcwxI63RhQ5G85Qqt4voZpUXSEqCwykV0baaOTQDR1f0PmY8AELqIyVc0NEZUj0Gov5lNGcXgsA==",
       "requires": {
         "@babel/runtime": "^7.1.2",
         "history": "^4.9.0",
         "loose-envify": "^1.3.1",
         "prop-types": "^15.6.2",
-        "react-router": "5.1.2",
+        "react-router": "5.2.0",
         "tiny-invariant": "^1.0.2",
         "tiny-warning": "^1.0.0"
+      }
+    },
+    "react-spring": {
+      "version": "8.0.27",
+      "resolved": "https://registry.npmjs.org/react-spring/-/react-spring-8.0.27.tgz",
+      "integrity": "sha512-nDpWBe3ZVezukNRandTeLSPcwwTMjNVu1IDq9qA/AMiUqHuRN4BeSWvKr3eIxxg1vtiYiOLy4FqdfCP5IoP77g==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "prop-types": "^15.5.8"
       }
     },
     "react-test-renderer": {
@@ -12164,26 +13112,31 @@
         }
       }
     },
+    "react-textarea-autosize": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.3.0.tgz",
+      "integrity": "sha512-3GLWFAan2pbwBeoeNDoqGmSbrShORtgWfaWX0RJDivsUrpShh01saRM5RU/i4Zmf+whpBVEY5cA90Eq8Ub1N3w==",
+      "requires": {
+        "@babel/runtime": "^7.10.2",
+        "use-composed-ref": "^1.0.0",
+        "use-latest": "^1.0.0"
+      }
+    },
     "react-transition-group": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.3.0.tgz",
-      "integrity": "sha512-1qRV1ZuVSdxPlPf4O8t7inxUGpdyO5zG9IoNfJxSO0ImU2A1YWkEQvFPuIPZmMLkg5hYs7vv5mMOyfgSkvAwvw==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.1.tgz",
+      "integrity": "sha512-Djqr7OQ2aPUiYurhPalTrVy9ddmFCCzwhqQmtN+J3+3DzLO209Fdr70QrN8Z3DsglWql6iY1lDWAfpFiBtuKGw==",
       "requires": {
         "@babel/runtime": "^7.5.5",
         "dom-helpers": "^5.0.1",
         "loose-envify": "^1.4.0",
         "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.8.3",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.3.tgz",
-          "integrity": "sha512-fVHx1rzEmwB130VTkLnxR+HmxcTjGzH12LYQcFFoBwakMd3aOMD4OsRN7tGG/UOYE2ektgFrS8uACAoRk1CY0w==",
-          "requires": {
-            "regenerator-runtime": "^0.13.2"
-          }
-        }
       }
+    },
+    "react-use-gesture": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/react-use-gesture/-/react-use-gesture-9.0.0.tgz",
+      "integrity": "sha512-inTAcmX0Y8LWr7XViim5+6XlTsJ7kCgwYRrwxSu1Vkjv+8GyClHITFkGGKYXAv5QywZ8YqiJXpzFx8RZpEVF+w=="
     },
     "react-with-direction": {
       "version": "1.3.1",
@@ -12198,6 +13151,13 @@
         "object.assign": "^4.1.0",
         "object.values": "^1.0.4",
         "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "deepmerge": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-1.5.2.tgz",
+          "integrity": "sha512-95k0GDqvBjZavkuvzx/YqVLv/6YYa17fz6ILMSf7neqQITCPbnfEnQvEgMPNjH4kgobe7+WIL0yJEHku+H3qtQ=="
+        }
       }
     },
     "react-with-styles": {
@@ -12267,6 +13227,69 @@
         "readable-stream": "^2.0.2"
       }
     },
+    "reakit": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/reakit/-/reakit-1.3.5.tgz",
+      "integrity": "sha512-Luv1RPBFlWhRG32Ysjd86KC+vLoz5da3X0O8rqClaNEv259nWmnw5fG6BIUSYJwTG6PPxTidPlS+9bS6nLstfA==",
+      "requires": {
+        "@popperjs/core": "^2.5.4",
+        "body-scroll-lock": "^3.1.5",
+        "reakit-system": "^0.15.1",
+        "reakit-utils": "^0.15.1",
+        "reakit-warning": "^0.6.1"
+      },
+      "dependencies": {
+        "reakit-system": {
+          "version": "0.15.1",
+          "resolved": "https://registry.npmjs.org/reakit-system/-/reakit-system-0.15.1.tgz",
+          "integrity": "sha512-PkqfAyEohtcEu/gUvKriCv42NywDtUgvocEN3147BI45dOFAB89nrT7wRIbIcKJiUT598F+JlPXAZZVLWhc1Kg==",
+          "requires": {
+            "reakit-utils": "^0.15.1"
+          }
+        },
+        "reakit-utils": {
+          "version": "0.15.1",
+          "resolved": "https://registry.npmjs.org/reakit-utils/-/reakit-utils-0.15.1.tgz",
+          "integrity": "sha512-6cZgKGvOkAMQgkwU9jdYbHfkuIN1Pr+vwcB19plLvcTfVN0Or10JhIuj9X+JaPZyI7ydqTDFaKNdUcDP69o/+Q=="
+        },
+        "reakit-warning": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/reakit-warning/-/reakit-warning-0.6.1.tgz",
+          "integrity": "sha512-poFUV0EyxB+CcV9uTNBAFmcgsnR2DzAbOTkld4Ul+QOKSeEHZB3b3+MoZQgcYHmbvG19Na1uWaM7ES+/Eyr8tQ==",
+          "requires": {
+            "reakit-utils": "^0.15.1"
+          }
+        }
+      }
+    },
+    "reakit-system": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/reakit-system/-/reakit-system-0.13.1.tgz",
+      "integrity": "sha512-qglfQ53FsJh5+VSkjMtBg7eZiowj9zXOyfJJxfaXh/XYTVe/5ibzWg6rvGHyvSm6C3D7Q2sg/NPCLmCtYGGvQA==",
+      "requires": {
+        "reakit-utils": "^0.13.1"
+      },
+      "dependencies": {
+        "reakit-utils": {
+          "version": "0.13.1",
+          "resolved": "https://registry.npmjs.org/reakit-utils/-/reakit-utils-0.13.1.tgz",
+          "integrity": "sha512-NBKgsot3tU91gZgK5MTInI/PR0T3kIsTmbU5MbGggSOcwU2dG/kbE8IrM2lC6ayCSL2W2QWkijT6kewdrIX7Gw=="
+        }
+      }
+    },
+    "reakit-utils": {
+      "version": "0.14.4",
+      "resolved": "https://registry.npmjs.org/reakit-utils/-/reakit-utils-0.14.4.tgz",
+      "integrity": "sha512-jDEf/NmZVJ6fs10G16ifD+RFhQikSLN7VfjRHu0CPoUj4g6lFXd5PPcRXCY81qiqc9FVHjr2d2fmsw1hs6xUxA=="
+    },
+    "reakit-warning": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/reakit-warning/-/reakit-warning-0.5.5.tgz",
+      "integrity": "sha512-OuP1r7rlSSJZsoLuc0CPA2ACPKnWO8HDbFktiiidbT67UjuX6udYV1AUsIgMJ8ado9K5gZGjPj7IB/GDYo9Yjg==",
+      "requires": {
+        "reakit-utils": "^0.14.4"
+      }
+    },
     "realpath-native": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-1.1.0.tgz",
@@ -12319,9 +13342,9 @@
       }
     },
     "redux": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.4.tgz",
-      "integrity": "sha512-vKv4WdiJxOWKxK0yRoaK3Y4pxxB0ilzVx6dszU2W8wLxlb2yikRph4iV/ymtdJ6ZxpBLFbyrxklnT5yBbQSl3Q==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.5.tgz",
+      "integrity": "sha512-VSz1uMAH24DM6MF72vcojpYPtrTUu3ByVWfPL1nPfVRb5mZVTve5GnNCUV53QM/BZ66xfWrm0CTWoM+Xlz8V1w==",
       "requires": {
         "loose-envify": "^1.4.0",
         "symbol-observable": "^1.2.0"
@@ -12348,9 +13371,9 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.13.2",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
-      "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
+      "version": "0.13.7",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
     },
     "regenerator-transform": {
       "version": "0.14.1",
@@ -12941,9 +13964,9 @@
       "dev": true
     },
     "scheduler": {
-      "version": "0.13.6",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.6.tgz",
-      "integrity": "sha512-IWnObHt413ucAYKsD9J1QShUKkbKLQQHdxRyw73sw4FN26iWr3DY/H34xGPe4nmL1DwXyWmSWmMrA9TfQbE/XQ==",
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
+      "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -12992,10 +14015,13 @@
       "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
     },
     "serialize-javascript": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.7.0.tgz",
-      "integrity": "sha512-ke8UG8ulpFOxO8f8gRYabHQe/ZntKlcig2Mp+8+URDP1D8vJZ0KUt7LYo07q25Z/+JVSgpr/cui9PIp5H6/+nA==",
-      "dev": true
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
+      "integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
+      "dev": true,
+      "requires": {
+        "randombytes": "^2.1.0"
+      }
     },
     "set-blocking": {
       "version": "2.0.0",
@@ -13029,7 +14055,8 @@
     "setimmediate": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
+      "dev": true
     },
     "sha.js": {
       "version": "2.4.11",
@@ -13069,76 +14096,24 @@
       "integrity": "sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg=="
     },
     "showdown": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/showdown/-/showdown-1.9.0.tgz",
-      "integrity": "sha512-x7xDCRIaOlicbC57nMhGfKamu+ghwsdVkHMttyn+DelwzuHOx4OHCVL/UW/2QOLH7BxfCcCCVVUix3boKXJKXQ==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/showdown/-/showdown-1.9.1.tgz",
+      "integrity": "sha512-9cGuS382HcvExtf5AHk7Cb4pAeQQ+h0eTr33V1mu+crYWV4KvWAw6el92bDrqGEk5d46Ai/fhbEUwqJ/mTCNEA==",
       "dev": true,
       "requires": {
-        "yargs": "^10.0.3"
+        "yargs": "^14.2"
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
           "dev": true
         },
-        "camelcase": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-          "dev": true
-        },
-        "cliui": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
-          "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
-          "dev": true,
-          "requires": {
-            "string-width": "^2.1.1",
-            "strip-ansi": "^4.0.0",
-            "wrap-ansi": "^2.0.0"
-          }
-        },
-        "cross-spawn": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^4.0.1",
-            "shebang-command": "^1.2.0",
-            "which": "^1.2.9"
-          }
-        },
-        "execa": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
-          "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
-          "dev": true,
-          "requires": {
-            "cross-spawn": "^5.0.1",
-            "get-stream": "^3.0.0",
-            "is-stream": "^1.1.0",
-            "npm-run-path": "^2.0.0",
-            "p-finally": "^1.0.0",
-            "signal-exit": "^3.0.0",
-            "strip-eof": "^1.0.0"
-          }
-        },
-        "find-up": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-          "dev": true,
-          "requires": {
-            "locate-path": "^2.0.0"
-          }
-        },
-        "get-stream": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+        "get-caller-file": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+          "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
           "dev": true
         },
         "is-fullwidth-code-point": {
@@ -13147,140 +14122,59 @@
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
-        "locate-path": {
+        "require-main-filename": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-          "dev": true,
-          "requires": {
-            "p-locate": "^2.0.0",
-            "path-exists": "^3.0.0"
-          }
-        },
-        "lru-cache": {
-          "version": "4.1.5",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-          "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-          "dev": true,
-          "requires": {
-            "pseudomap": "^1.0.2",
-            "yallist": "^2.1.2"
-          }
-        },
-        "mem": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
-          "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
-          "dev": true,
-          "requires": {
-            "mimic-fn": "^1.0.0"
-          }
-        },
-        "mimic-fn": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-          "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
-          "dev": true
-        },
-        "os-locale": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-          "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
-          "dev": true,
-          "requires": {
-            "execa": "^0.7.0",
-            "lcid": "^1.0.0",
-            "mem": "^1.1.0"
-          }
-        },
-        "p-limit": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-          "dev": true,
-          "requires": {
-            "p-try": "^1.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-          "dev": true,
-          "requires": {
-            "p-limit": "^1.1.0"
-          }
-        },
-        "p-try": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+          "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
           "dev": true
         },
         "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
           "dev": true,
           "requires": {
+            "emoji-regex": "^7.0.1",
             "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
+            "strip-ansi": "^5.1.0"
           }
         },
         "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "^4.1.0"
           }
         },
-        "which-module": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
-          "dev": true
-        },
-        "y18n": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-          "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
-          "dev": true
-        },
-        "yallist": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
-          "dev": true
-        },
         "yargs": {
-          "version": "10.1.2",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-10.1.2.tgz",
-          "integrity": "sha512-ivSoxqBGYOqQVruxD35+EyCFDYNEFL/Uo6FcOnz+9xZdZzK0Zzw4r4KhbrME1Oo2gOggwJod2MnsdamSG7H9ig==",
+          "version": "14.2.3",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-14.2.3.tgz",
+          "integrity": "sha512-ZbotRWhF+lkjijC/VhmOT9wSgyBQ7+zr13+YLkhfsSiTriYsMzkTUFP18pFhWwBeMa5gUc1MzbhrO6/VB7c9Xg==",
           "dev": true,
           "requires": {
-            "cliui": "^4.0.0",
-            "decamelize": "^1.1.1",
-            "find-up": "^2.1.0",
-            "get-caller-file": "^1.0.1",
-            "os-locale": "^2.0.0",
+            "cliui": "^5.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^2.0.1",
             "require-directory": "^2.1.1",
-            "require-main-filename": "^1.0.1",
+            "require-main-filename": "^2.0.0",
             "set-blocking": "^2.0.0",
-            "string-width": "^2.0.0",
+            "string-width": "^3.0.0",
             "which-module": "^2.0.0",
-            "y18n": "^3.2.1",
-            "yargs-parser": "^8.1.0"
+            "y18n": "^4.0.0",
+            "yargs-parser": "^15.0.1"
           }
         },
         "yargs-parser": {
-          "version": "8.1.0",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.1.0.tgz",
-          "integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
+          "version": "15.0.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.1.tgz",
+          "integrity": "sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==",
           "dev": true,
           "requires": {
-            "camelcase": "^4.1.0"
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
           }
         }
       }
@@ -13292,9 +14186,9 @@
       "dev": true
     },
     "simple-html-tokenizer": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/simple-html-tokenizer/-/simple-html-tokenizer-0.5.7.tgz",
-      "integrity": "sha512-APW9iYbkJ5cijjX4Ljhf3VG8SwYPUJT5gZrwci/wieMabQxWFiV5VwsrP5c6GMRvXKEQMGkAB1d9dvW66dTqpg==",
+      "version": "0.5.11",
+      "resolved": "https://registry.npmjs.org/simple-html-tokenizer/-/simple-html-tokenizer-0.5.11.tgz",
+      "integrity": "sha512-C2WEK/Z3HoSFbYq8tI7ni3eOo/NneSPRoPpcM7WdLjFOArFuyXEjAoCdOC3DgMfRyziZQ1hCNR4mrNdWEvD0og==",
       "dev": true
     },
     "simple-swizzle": {
@@ -13464,8 +14358,7 @@
     "source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-      "dev": true
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
     },
     "source-map-resolve": {
       "version": "0.5.2",
@@ -13670,6 +14563,11 @@
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
       "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY="
     },
+    "string-convert": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/string-convert/-/string-convert-0.2.1.tgz",
+      "integrity": "sha1-aYLMMEn7tM2F+LJFaLnZvznu/5c="
+    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -13815,8 +14713,21 @@
     "strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-      "dev": true
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+    },
+    "style-value-types": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/style-value-types/-/style-value-types-3.2.0.tgz",
+      "integrity": "sha512-ih0mGsrYYmVvdDi++/66O6BaQPRPRMQHoZevNNdMMcPlP/cH28Rnfsqf1UEba/Bwfuw9T8BmIMwbGdzsPwQKrQ==",
+      "requires": {
+        "hey-listen": "^1.0.8",
+        "tslib": "^1.10.0"
+      }
+    },
+    "styled-griddie": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/styled-griddie/-/styled-griddie-0.1.3.tgz",
+      "integrity": "sha512-RjsiiADJrRpdPTF8NR26nlZutnvkrX78tiM5/za/E+ftVdpjD8ZBb2iOzrIzfix80uDcHYQbg3iIR0lOGaYmEQ=="
     },
     "stylehacks": {
       "version": "4.0.3",
@@ -13959,11 +14870,11 @@
       }
     },
     "tannin": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/tannin/-/tannin-1.1.0.tgz",
-      "integrity": "sha512-LxhcXqpMHEOVeVKmuG5aCPPsTXFlO373vrWkqN7FSJBVLS6lFOAg8ZGzIyGhrOf7Ho3xB4jdGedY1gi/8J1FCA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tannin/-/tannin-1.2.0.tgz",
+      "integrity": "sha512-U7GgX/RcSeUETbV7gYgoz8PD7Ni4y95pgIP/Z6ayI3CfhSujwKEBlGFTCRN+Aqnuyf4AN2yHL+L8x+TCGjb9uA==",
       "requires": {
-        "@tannin/plural-forms": "^1.0.3"
+        "@tannin/plural-forms": "^1.1.0"
       }
     },
     "tapable": {
@@ -13984,14 +14895,14 @@
       }
     },
     "terser": {
-      "version": "3.17.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-3.17.0.tgz",
-      "integrity": "sha512-/FQzzPJmCpjAH9Xvk2paiWrFq+5M6aVOf+2KRbwhByISDX/EujxsK+BAvrhb6H+2rtrLCHK9N01wO014vrIwVQ==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-4.8.0.tgz",
+      "integrity": "sha512-EAPipTNeWsb/3wLPeup1tVPaXfIaU68xMnVdPafIL1TV05OhASArYyIfFvnvJCNrR2NIOvDVNNTFRa+Re2MWyw==",
       "dev": true,
       "requires": {
-        "commander": "^2.19.0",
+        "commander": "^2.20.0",
         "source-map": "~0.6.1",
-        "source-map-support": "~0.5.10"
+        "source-map-support": "~0.5.12"
       },
       "dependencies": {
         "source-map": {
@@ -14003,19 +14914,20 @@
       }
     },
     "terser-webpack-plugin": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.2.3.tgz",
-      "integrity": "sha512-GOK7q85oAb/5kE12fMuLdn2btOS9OBZn4VsecpHDywoUC/jLhSAKOiYo0ezx7ss2EXPMzyEWFoE0s1WLE+4+oA==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.5.tgz",
+      "integrity": "sha512-04Rfe496lN8EYruwi6oPQkG0vo8C+HT49X687FZnpPF0qMAIHONI6HEXYPKDOE8e5HjXTyKfqRd/agHtH0kOtw==",
       "dev": true,
       "requires": {
-        "cacache": "^11.0.2",
-        "find-cache-dir": "^2.0.0",
+        "cacache": "^12.0.2",
+        "find-cache-dir": "^2.1.0",
+        "is-wsl": "^1.1.0",
         "schema-utils": "^1.0.0",
-        "serialize-javascript": "^1.4.0",
+        "serialize-javascript": "^4.0.0",
         "source-map": "^0.6.1",
-        "terser": "^3.16.1",
-        "webpack-sources": "^1.1.0",
-        "worker-farm": "^1.5.2"
+        "terser": "^4.1.2",
+        "webpack-sources": "^1.4.0",
+        "worker-farm": "^1.7.0"
       },
       "dependencies": {
         "source-map": {
@@ -14023,6 +14935,16 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
+        },
+        "webpack-sources": {
+          "version": "1.4.3",
+          "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.3.tgz",
+          "integrity": "sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==",
+          "dev": true,
+          "requires": {
+            "source-list-map": "^2.0.0",
+            "source-map": "~0.6.1"
+          }
         }
       }
     },
@@ -14106,9 +15028,9 @@
       "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q=="
     },
     "tiny-invariant": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.0.6.tgz",
-      "integrity": "sha512-FOyLWWVjG+aC0UqG76V53yAWdXfH8bO6FNmyZOuUrzDzK8DI3/JRY25UD7+g49JWM1LXwymsKERB+DzI0dTEQA=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.1.0.tgz",
+      "integrity": "sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw=="
     },
     "tiny-warning": {
       "version": "1.0.3",
@@ -14116,9 +15038,9 @@
       "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
     },
     "tinycolor2": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.4.1.tgz",
-      "integrity": "sha1-9PrTM0R7wLB9TcjpIJ2POaisd+g="
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.4.2.tgz",
+      "integrity": "sha512-vJhccZPs965sV/L2sU4oRQVAos0pQXwsvTLkWYdqJ+a8Q5kPFzJTuOFwy7UniPli44NKQGAglksjvOcpo95aZA=="
     },
     "tmp": {
       "version": "0.0.33",
@@ -14144,8 +15066,7 @@
     "to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-      "dev": true
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
     },
     "to-object-path": {
       "version": "0.3.0",
@@ -14189,6 +15110,11 @@
         "repeat-string": "^1.6.1"
       }
     },
+    "toggle-selection": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
+      "integrity": "sha1-bkWxJj8gF/oKzH2J14sVuL932jI="
+    },
     "tough-cookie": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
@@ -14229,11 +15155,15 @@
         "glob": "^7.1.2"
       }
     },
+    "ts-essentials": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-2.0.12.tgz",
+      "integrity": "sha512-3IVX4nI6B5cc31/GFFE+i8ey/N2eA0CZDbo6n0yrz0zDX8ZJ8djmU1p+XRz7G3is0F3bB3pu2pAroFdAWQKU3w=="
+    },
     "tslib": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
-      "dev": true
+      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
     },
     "tty-browserify": {
       "version": "0.0.0",
@@ -14281,11 +15211,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.2.tgz",
       "integrity": "sha512-ml7V7JfiN2Xwvcer+XAf2csGO1bPBdRbFCkYBczNZggrBZ9c7G3riSUeJmqEU5uOtXNPMhE3n+R4FA/3YOAWOQ==",
       "dev": true
-    },
-    "ua-parser-js": {
-      "version": "0.7.21",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.21.tgz",
-      "integrity": "sha512-+O8/qh/Qj8CgC6eYBVBykMrNtp5Gebn4dlGD/kKXVkJNDwyrAwSIqwz8CDf+tsAIWVycKcku6gIXJ0qwx/ZXaQ=="
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",
@@ -14448,6 +15373,41 @@
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
       "dev": true
     },
+    "use-composed-ref": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.1.0.tgz",
+      "integrity": "sha512-my1lNHGWsSDAhhVAT4MKs6IjBUtG6ZG11uUqexPH9PptiIZDQOzaF4f5tEbJ2+7qvNbtXNBbU3SfmN+fXlWDhg==",
+      "requires": {
+        "ts-essentials": "^2.0.3"
+      }
+    },
+    "use-enhanced-state": {
+      "version": "0.0.13",
+      "resolved": "https://registry.npmjs.org/use-enhanced-state/-/use-enhanced-state-0.0.13.tgz",
+      "integrity": "sha512-RCtUQdhfUXu/0GAQqLnKPetUt3BheYFpOTogppHe9x1XGwluiu6DQLKVNnc3yMfj0HM3IOVBgw5nVJJuZS5TWQ==",
+      "requires": {
+        "@itsjonq/is": "0.0.2",
+        "tiny-warning": "^1.0.3"
+      }
+    },
+    "use-isomorphic-layout-effect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.1.tgz",
+      "integrity": "sha512-L7Evj8FGcwo/wpbv/qvSfrkHFtOpCzvM5yl2KVyDJoylVuSvzphiiasmjgQPttIGBAy2WKiBNR98q8w7PiNgKQ=="
+    },
+    "use-latest": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-latest/-/use-latest-1.2.0.tgz",
+      "integrity": "sha512-d2TEuG6nSLKQLAfW3By8mKr8HurOlTkul0sOpxbClIv4SQ4iOd7BYr7VIzdbktUCnv7dua/60xzd8igMU6jmyw==",
+      "requires": {
+        "use-isomorphic-layout-effect": "^1.0.0"
+      }
+    },
+    "use-memo-one": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/use-memo-one/-/use-memo-one-1.1.2.tgz",
+      "integrity": "sha512-u2qFKtxLsia/r8qG0ZKkbytbztzRb317XCkT7yP8wxL0tZ/CzK2G+WWie5vWvpyeP7+YoPIwbJoIHJ4Ba4k0oQ=="
+    },
     "util": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/util/-/util-0.11.1.tgz",
@@ -14558,6 +15518,39 @@
         "neo-async": "^2.5.0"
       }
     },
+    "watchpack-chokidar2": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/watchpack-chokidar2/-/watchpack-chokidar2-2.0.1.tgz",
+      "integrity": "sha512-nCFfBIPKr5Sh61s4LPpy1Wtfi0HE8isJ3d2Yb5/Ppw2P2B/3eVSEBjKfN0fmHJSK14+31KwMKmcrzs2GM4P0Ww==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "chokidar": "^2.1.8"
+      },
+      "dependencies": {
+        "chokidar": {
+          "version": "2.1.8",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
+          "integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "anymatch": "^2.0.0",
+            "async-each": "^1.0.1",
+            "braces": "^2.3.2",
+            "fsevents": "^1.2.7",
+            "glob-parent": "^3.1.0",
+            "inherits": "^2.0.3",
+            "is-binary-path": "^1.0.0",
+            "is-glob": "^4.0.0",
+            "normalize-path": "^3.0.0",
+            "path-is-absolute": "^1.0.0",
+            "readdirp": "^2.2.1",
+            "upath": "^1.1.1"
+          }
+        }
+      }
+    },
     "webidl-conversions": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
@@ -14565,34 +15558,410 @@
       "dev": true
     },
     "webpack": {
-      "version": "4.35.3",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.35.3.tgz",
-      "integrity": "sha512-xggQPwr9ILlXzz61lHzjvgoqGU08v5+Wnut19Uv3GaTtzN4xBTcwnobodrXE142EL1tOiS5WVEButooGzcQzTA==",
+      "version": "4.46.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.46.0.tgz",
+      "integrity": "sha512-6jJuJjg8znb/xRItk7bkT0+Q7AHCYjjFnvKIWQPkNIOyRqoCGvkOs0ipeQzrqz4l5FtN5ZI/ukEHroeX/o1/5Q==",
       "dev": true,
       "requires": {
-        "@webassemblyjs/ast": "1.8.5",
-        "@webassemblyjs/helper-module-context": "1.8.5",
-        "@webassemblyjs/wasm-edit": "1.8.5",
-        "@webassemblyjs/wasm-parser": "1.8.5",
-        "acorn": "^6.2.0",
-        "ajv": "^6.1.0",
-        "ajv-keywords": "^3.1.0",
-        "chrome-trace-event": "^1.0.0",
-        "enhanced-resolve": "^4.1.0",
-        "eslint-scope": "^4.0.0",
+        "@webassemblyjs/ast": "1.9.0",
+        "@webassemblyjs/helper-module-context": "1.9.0",
+        "@webassemblyjs/wasm-edit": "1.9.0",
+        "@webassemblyjs/wasm-parser": "1.9.0",
+        "acorn": "^6.4.1",
+        "ajv": "^6.10.2",
+        "ajv-keywords": "^3.4.1",
+        "chrome-trace-event": "^1.0.2",
+        "enhanced-resolve": "^4.5.0",
+        "eslint-scope": "^4.0.3",
         "json-parse-better-errors": "^1.0.2",
-        "loader-runner": "^2.3.0",
-        "loader-utils": "^1.1.0",
-        "memory-fs": "~0.4.1",
-        "micromatch": "^3.1.8",
-        "mkdirp": "~0.5.0",
-        "neo-async": "^2.5.0",
-        "node-libs-browser": "^2.0.0",
+        "loader-runner": "^2.4.0",
+        "loader-utils": "^1.2.3",
+        "memory-fs": "^0.4.1",
+        "micromatch": "^3.1.10",
+        "mkdirp": "^0.5.3",
+        "neo-async": "^2.6.1",
+        "node-libs-browser": "^2.2.1",
         "schema-utils": "^1.0.0",
-        "tapable": "^1.1.0",
-        "terser-webpack-plugin": "^1.1.0",
-        "watchpack": "^1.5.0",
-        "webpack-sources": "^1.3.0"
+        "tapable": "^1.1.3",
+        "terser-webpack-plugin": "^1.4.3",
+        "watchpack": "^1.7.4",
+        "webpack-sources": "^1.4.1"
+      },
+      "dependencies": {
+        "@webassemblyjs/ast": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.9.0.tgz",
+          "integrity": "sha512-C6wW5L+b7ogSDVqymbkkvuW9kruN//YisMED04xzeBBqjHa2FYnmvOlS6Xj68xWQRgWvI9cIglsjFowH/RJyEA==",
+          "dev": true,
+          "requires": {
+            "@webassemblyjs/helper-module-context": "1.9.0",
+            "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
+            "@webassemblyjs/wast-parser": "1.9.0"
+          }
+        },
+        "@webassemblyjs/floating-point-hex-parser": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.9.0.tgz",
+          "integrity": "sha512-TG5qcFsS8QB4g4MhrxK5TqfdNe7Ey/7YL/xN+36rRjl/BlGE/NcBvJcqsRgCP6Z92mRE+7N50pRIi8SmKUbcQA==",
+          "dev": true
+        },
+        "@webassemblyjs/helper-api-error": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.9.0.tgz",
+          "integrity": "sha512-NcMLjoFMXpsASZFxJ5h2HZRcEhDkvnNFOAKneP5RbKRzaWJN36NC4jqQHKwStIhGXu5mUWlUUk7ygdtrO8lbmw==",
+          "dev": true
+        },
+        "@webassemblyjs/helper-buffer": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.9.0.tgz",
+          "integrity": "sha512-qZol43oqhq6yBPx7YM3m9Bv7WMV9Eevj6kMi6InKOuZxhw+q9hOkvq5e/PpKSiLfyetpaBnogSbNCfBwyB00CA==",
+          "dev": true
+        },
+        "@webassemblyjs/helper-code-frame": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.9.0.tgz",
+          "integrity": "sha512-ERCYdJBkD9Vu4vtjUYe8LZruWuNIToYq/ME22igL+2vj2dQ2OOujIZr3MEFvfEaqKoVqpsFKAGsRdBSBjrIvZA==",
+          "dev": true,
+          "requires": {
+            "@webassemblyjs/wast-printer": "1.9.0"
+          }
+        },
+        "@webassemblyjs/helper-fsm": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-fsm/-/helper-fsm-1.9.0.tgz",
+          "integrity": "sha512-OPRowhGbshCb5PxJ8LocpdX9Kl0uB4XsAjl6jH/dWKlk/mzsANvhwbiULsaiqT5GZGT9qinTICdj6PLuM5gslw==",
+          "dev": true
+        },
+        "@webassemblyjs/helper-module-context": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-module-context/-/helper-module-context-1.9.0.tgz",
+          "integrity": "sha512-MJCW8iGC08tMk2enck1aPW+BE5Cw8/7ph/VGZxwyvGbJwjktKkDK7vy7gAmMDx88D7mhDTCNKAW5tED+gZ0W8g==",
+          "dev": true,
+          "requires": {
+            "@webassemblyjs/ast": "1.9.0"
+          }
+        },
+        "@webassemblyjs/helper-wasm-bytecode": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.9.0.tgz",
+          "integrity": "sha512-R7FStIzyNcd7xKxCZH5lE0Bqy+hGTwS3LJjuv1ZVxd9O7eHCedSdrId/hMOd20I+v8wDXEn+bjfKDLzTepoaUw==",
+          "dev": true
+        },
+        "@webassemblyjs/helper-wasm-section": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.9.0.tgz",
+          "integrity": "sha512-XnMB8l3ek4tvrKUUku+IVaXNHz2YsJyOOmz+MMkZvh8h1uSJpSen6vYnw3IoQ7WwEuAhL8Efjms1ZWjqh2agvw==",
+          "dev": true,
+          "requires": {
+            "@webassemblyjs/ast": "1.9.0",
+            "@webassemblyjs/helper-buffer": "1.9.0",
+            "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
+            "@webassemblyjs/wasm-gen": "1.9.0"
+          }
+        },
+        "@webassemblyjs/ieee754": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.9.0.tgz",
+          "integrity": "sha512-dcX8JuYU/gvymzIHc9DgxTzUUTLexWwt8uCTWP3otys596io0L5aW02Gb1RjYpx2+0Jus1h4ZFqjla7umFniTg==",
+          "dev": true,
+          "requires": {
+            "@xtuc/ieee754": "^1.2.0"
+          }
+        },
+        "@webassemblyjs/leb128": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.9.0.tgz",
+          "integrity": "sha512-ENVzM5VwV1ojs9jam6vPys97B/S65YQtv/aanqnU7D8aSoHFX8GyhGg0CMfyKNIHBuAVjy3tlzd5QMMINa7wpw==",
+          "dev": true,
+          "requires": {
+            "@xtuc/long": "4.2.2"
+          }
+        },
+        "@webassemblyjs/utf8": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.9.0.tgz",
+          "integrity": "sha512-GZbQlWtopBTP0u7cHrEx+73yZKrQoBMpwkGEIqlacljhXCkVM1kMQge/Mf+csMJAjEdSwhOyLAS0AoR3AG5P8w==",
+          "dev": true
+        },
+        "@webassemblyjs/wasm-edit": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.9.0.tgz",
+          "integrity": "sha512-FgHzBm80uwz5M8WKnMTn6j/sVbqilPdQXTWraSjBwFXSYGirpkSWE2R9Qvz9tNiTKQvoKILpCuTjBKzOIm0nxw==",
+          "dev": true,
+          "requires": {
+            "@webassemblyjs/ast": "1.9.0",
+            "@webassemblyjs/helper-buffer": "1.9.0",
+            "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
+            "@webassemblyjs/helper-wasm-section": "1.9.0",
+            "@webassemblyjs/wasm-gen": "1.9.0",
+            "@webassemblyjs/wasm-opt": "1.9.0",
+            "@webassemblyjs/wasm-parser": "1.9.0",
+            "@webassemblyjs/wast-printer": "1.9.0"
+          }
+        },
+        "@webassemblyjs/wasm-gen": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.9.0.tgz",
+          "integrity": "sha512-cPE3o44YzOOHvlsb4+E9qSqjc9Qf9Na1OO/BHFy4OI91XDE14MjFN4lTMezzaIWdPqHnsTodGGNP+iRSYfGkjA==",
+          "dev": true,
+          "requires": {
+            "@webassemblyjs/ast": "1.9.0",
+            "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
+            "@webassemblyjs/ieee754": "1.9.0",
+            "@webassemblyjs/leb128": "1.9.0",
+            "@webassemblyjs/utf8": "1.9.0"
+          }
+        },
+        "@webassemblyjs/wasm-opt": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.9.0.tgz",
+          "integrity": "sha512-Qkjgm6Anhm+OMbIL0iokO7meajkzQD71ioelnfPEj6r4eOFuqm4YC3VBPqXjFyyNwowzbMD+hizmprP/Fwkl2A==",
+          "dev": true,
+          "requires": {
+            "@webassemblyjs/ast": "1.9.0",
+            "@webassemblyjs/helper-buffer": "1.9.0",
+            "@webassemblyjs/wasm-gen": "1.9.0",
+            "@webassemblyjs/wasm-parser": "1.9.0"
+          }
+        },
+        "@webassemblyjs/wasm-parser": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.9.0.tgz",
+          "integrity": "sha512-9+wkMowR2AmdSWQzsPEjFU7njh8HTO5MqO8vjwEHuM+AMHioNqSBONRdr0NQQ3dVQrzp0s8lTcYqzUdb7YgELA==",
+          "dev": true,
+          "requires": {
+            "@webassemblyjs/ast": "1.9.0",
+            "@webassemblyjs/helper-api-error": "1.9.0",
+            "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
+            "@webassemblyjs/ieee754": "1.9.0",
+            "@webassemblyjs/leb128": "1.9.0",
+            "@webassemblyjs/utf8": "1.9.0"
+          }
+        },
+        "@webassemblyjs/wast-parser": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-parser/-/wast-parser-1.9.0.tgz",
+          "integrity": "sha512-qsqSAP3QQ3LyZjNC/0jBJ/ToSxfYJ8kYyuiGvtn/8MK89VrNEfwj7BPQzJVHi0jGTRK2dGdJ5PRqhtjzoww+bw==",
+          "dev": true,
+          "requires": {
+            "@webassemblyjs/ast": "1.9.0",
+            "@webassemblyjs/floating-point-hex-parser": "1.9.0",
+            "@webassemblyjs/helper-api-error": "1.9.0",
+            "@webassemblyjs/helper-code-frame": "1.9.0",
+            "@webassemblyjs/helper-fsm": "1.9.0",
+            "@xtuc/long": "4.2.2"
+          }
+        },
+        "@webassemblyjs/wast-printer": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.9.0.tgz",
+          "integrity": "sha512-2J0nE95rHXHyQ24cWjMKJ1tqB/ds8z/cyeOZxJhcb+rW+SQASVjuznUSmdz5GpVJTzU8JkhYut0D3siFDD6wsA==",
+          "dev": true,
+          "requires": {
+            "@webassemblyjs/ast": "1.9.0",
+            "@webassemblyjs/wast-parser": "1.9.0",
+            "@xtuc/long": "4.2.2"
+          }
+        },
+        "acorn": {
+          "version": "6.4.2",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz",
+          "integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==",
+          "dev": true
+        },
+        "ajv": {
+          "version": "6.12.6",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "anymatch": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+          "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "normalize-path": "^3.0.0",
+            "picomatch": "^2.0.4"
+          }
+        },
+        "binary-extensions": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+          "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+          "dev": true,
+          "optional": true
+        },
+        "braces": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "fill-range": "^7.0.1"
+          }
+        },
+        "chokidar": {
+          "version": "3.5.1",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.1.tgz",
+          "integrity": "sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "anymatch": "~3.1.1",
+            "braces": "~3.0.2",
+            "fsevents": "~2.3.1",
+            "glob-parent": "~5.1.0",
+            "is-binary-path": "~2.1.0",
+            "is-glob": "~4.0.1",
+            "normalize-path": "~3.0.0",
+            "readdirp": "~3.5.0"
+          }
+        },
+        "enhanced-resolve": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.5.0.tgz",
+          "integrity": "sha512-Nv9m36S/vxpsI+Hc4/ZGRs0n9mXqSWGGq49zxb/cJfPAQMbUtttJAlNPS4AQzaBdw/pKskw5bMbekT/Y7W/Wlg==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "memory-fs": "^0.5.0",
+            "tapable": "^1.0.0"
+          },
+          "dependencies": {
+            "memory-fs": {
+              "version": "0.5.0",
+              "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.5.0.tgz",
+              "integrity": "sha512-jA0rdU5KoQMC0e6ppoNRtpp6vjFq6+NY7r8hywnC7V+1Xj/MtHwGIbB1QaK/dunyjWteJzmkpd7ooeWg10T7GA==",
+              "dev": true,
+              "requires": {
+                "errno": "^0.1.3",
+                "readable-stream": "^2.0.1"
+              }
+            }
+          }
+        },
+        "fast-deep-equal": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+          "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+          "dev": true
+        },
+        "fill-range": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "to-regex-range": "^5.0.1"
+          }
+        },
+        "fsevents": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.1.tgz",
+          "integrity": "sha512-YR47Eg4hChJGAB1O3yEAOkGO+rlzutoICGqGo9EZ4lKWokzZRSyIW1QmTzqjtw8MJdj9srP869CuWw/hyzSiBw==",
+          "dev": true,
+          "optional": true
+        },
+        "glob-parent": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
+          "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "is-glob": "^4.0.1"
+          }
+        },
+        "is-binary-path": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+          "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "binary-extensions": "^2.0.0"
+          }
+        },
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+          "dev": true,
+          "optional": true
+        },
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.5",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.5"
+          }
+        },
+        "readdirp": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
+          "integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "picomatch": "^2.2.1"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "is-number": "^7.0.0"
+          }
+        },
+        "watchpack": {
+          "version": "1.7.5",
+          "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.7.5.tgz",
+          "integrity": "sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==",
+          "dev": true,
+          "requires": {
+            "chokidar": "^3.4.1",
+            "graceful-fs": "^4.1.2",
+            "neo-async": "^2.5.0",
+            "watchpack-chokidar2": "^2.0.1"
+          }
+        },
+        "webpack-sources": {
+          "version": "1.4.3",
+          "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.3.tgz",
+          "integrity": "sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==",
+          "dev": true,
+          "requires": {
+            "source-list-map": "^2.0.0",
+            "source-map": "~0.6.1"
+          }
+        }
       }
     },
     "webpack-cli": {
@@ -14760,11 +16129,6 @@
         "iconv-lite": "0.4.24"
       }
     },
-    "whatwg-fetch": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
-      "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
-    },
     "whatwg-mimetype": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
@@ -14780,6 +16144,37 @@
         "lodash.sortby": "^4.7.0",
         "tr46": "^1.0.1",
         "webidl-conversions": "^4.0.2"
+      }
+    },
+    "whatwg-url-without-unicode": {
+      "version": "8.0.0-3",
+      "resolved": "https://registry.npmjs.org/whatwg-url-without-unicode/-/whatwg-url-without-unicode-8.0.0-3.tgz",
+      "integrity": "sha512-HoKuzZrUlgpz35YO27XgD28uh/WJH4B0+3ttFqRo//lmq+9T/mIOJ6kqmINI9HpUpz1imRC/nR/lxKpJiv0uig==",
+      "requires": {
+        "buffer": "^5.4.3",
+        "punycode": "^2.1.1",
+        "webidl-conversions": "^5.0.0"
+      },
+      "dependencies": {
+        "base64-js": {
+          "version": "1.5.1",
+          "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+          "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+        },
+        "buffer": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+          "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.1.13"
+          }
+        },
+        "webidl-conversions": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
+          "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA=="
+        }
       }
     },
     "which": {
@@ -14888,6 +16283,11 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
       "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
       "dev": true
+    },
+    "yaml": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.0.tgz",
+      "integrity": "sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg=="
     },
     "yargs": {
       "version": "13.3.0",

--- a/package.json
+++ b/package.json
@@ -3,9 +3,11 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "newspack-components": "^1.0.3",
+    "@wordpress/base-styles": "^3.3.2",
+    "@wordpress/components": "^12.0.5",
+    "newspack-components": "^1.4.0",
     "npm-run-all": "^4.1.5",
-    "query-string": "^6.9.0"
+    "query-string": "^6.13.8"
   },
   "scripts": {
     "build:js": "calypso-build",
@@ -20,13 +22,13 @@
   },
   "devDependencies": {
     "@automattic/calypso-build": "^5.1.0",
-    "@babel/core": "^7.4.0",
-    "@wordpress/blocks": "^6.2.0",
-    "@wordpress/browserslist-config": "^2.2.2",
-    "@wordpress/data": "^4.6.0",
-    "@wordpress/element": "^2.3.0",
+    "@babel/core": "^7.12.13",
+    "@wordpress/blocks": "^6.25.2",
+    "@wordpress/browserslist-config": "^2.7.0",
+    "@wordpress/data": "^4.26.5",
+    "@wordpress/element": "^2.19.1",
     "eslint": "^5.16.0",
     "prettier": "https://github.com/Automattic/wp-prettier/releases/download/wp-1.16.4/wp-prettier-1.16.4.tgz",
-    "webpack": "^4.29.6"
+    "webpack": "^4.46.0"
   }
 }


### PR DESCRIPTION
In preparation of uploading this plugin to the wporg directory, this PR replaces most of the components with WordPress's (with the exception of `NewspackLogo`).

This allows a more generic look-and-feel whilst keeping the branding discreetly at the bottom.

Non-Newspack users won't be welcomed by an unfamiliar interface anymore.

__Screenshots__

![Screenshot 2021-02-05 at 18 27 18](https://user-images.githubusercontent.com/177929/107074126-34235c80-67e0-11eb-863b-0c1daa708e3f.png)
![Screenshot 2021-02-05 at 18 27 28](https://user-images.githubusercontent.com/177929/107074132-35548980-67e0-11eb-99f1-a17805288129.png)
![Screenshot 2021-02-05 at 18 27 31](https://user-images.githubusercontent.com/177929/107074134-35548980-67e0-11eb-9b81-43cfe8feec9a.png)

