### PR TITLE
Fixes overlay visibility in Gutenberg

### DIFF
--- a/assets/src/style.scss
+++ b/assets/src/style.scss
@@ -55,7 +55,7 @@ body[class*="newspack-content-converter_"] {
 	display: flex;
 	flex-direction: column;
 	left: 0;
-	overflow-y: auto;
+	overflow-y: inherit;
 	position: absolute;
 	right: 0;
 	top: 0;


### PR DESCRIPTION
In Chrome, the actual conversion screen was entirely blue since the new WP 5.8.1 version and the GUI progress wasn't visible, e.g.:
![image](https://user-images.githubusercontent.com/29167323/140321951-106202d2-da9e-4e44-9d05-34fd3705b0af.png)

Workflow:
- create a test post with Classic HTML
- click Newspack Content Converter in left-side WP Admin menu
- click the blue button to actually start running conversion

Updating this one CSS line fixes it, just please check that `inherit` is the correct value. Thanks!
![image](https://user-images.githubusercontent.com/29167323/140322141-b2ee28ca-78a5-4689-91a6-95d6afc2ce0e.png)

Additionally, I'm noticing that Firefox and Safari don't display the GUI well. This is a know problem, and if I'm not mistaken we've ignored it until now, because it worked fine in Chrome:

![image](https://user-images.githubusercontent.com/29167323/140322348-0148b159-b8f7-45c3-90ac-3a6f53a40dbf.png)

![image](https://user-images.githubusercontent.com/29167323/140322429-76deed26-e7f1-4d39-b2a2-384fa4213d5d.png)

