### PR TITLE
Update uninstall.php

### DIFF
--- a/uninstall.php
+++ b/uninstall.php
@@ -8,6 +8,6 @@
 namespace NewspackContentConverter;
 
 // TODO: Switch to Composer autoloading.
-require_once dirname( __FILE__ ) . '/dependency-includer-script.php';
+require __DIR__ . '/vendor/autoload.php';
 
 \NewspackContentConverter\Installer::uninstall_plugin();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Changes a line in the uninstall script to use Composer, enabling proper uninstallation of the plugin.

Closes #100; supersedes #102.

### How to test the changes in this Pull Request:

1. Install the Newspack Content Converter. No need to activate it.
2. Try deleting the plugin from `/wp-admin`. It will hang.
3. Change line 11 as detailed in this PR.
4. Try deleting the plugin. "Newspack Content Converter was successfully deleted." 💥

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->