### PR TITLE
Bump composer installers version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
       ]
     },
     "require": {
-        "composer/installers": "^1.6",
+        "composer/installers": "^2.2",
         "brainmaestro/composer-git-hooks": "^2.6"
     },
     "require-dev": {


### PR DESCRIPTION
Bumps the version of composer/installers used so that it matches the main newspack-plugin. Without this change, projects that have this plugin and newspack-plugin as dependencies won't be able to resolve to an installable set of packages due to the version conflict.