### PR TITLE
adding new actions for post-processing

### DIFF
--- a/lib/class-conversionprocessor.php
+++ b/lib/class-conversionprocessor.php
@@ -162,6 +162,8 @@ class ConversionProcessor {
 		$blocks_content_patched = $this->patcher_handler->run_all_patches( $html_content, $blocks_content );
 		$this->update_ncc_posts_table( $post_id, [ 'post_content_gutenberg_converted' => $blocks_content ] );
 		$this->update_posts_table( $post_id, [ 'post_content' => $blocks_content_patched ] );
+
+		do_action( 'ncc_after_post_content_saved', $post_id, $blocks_content_patched, $html_content, $blocks_content );
 	}
 
 	/**
@@ -184,6 +186,8 @@ class ConversionProcessor {
 
 		// phpcs:ignore -- OK to query DB directly.
 		$wpdb->update( $table_name, array_merge( $data, $timestamps ), [ 'ID' => $post_id ] );
+
+		do_action( 'ncc_after_post_table_update', 'ncc', $post_id, $data );
 	}
 
 	/**
@@ -205,6 +209,8 @@ class ConversionProcessor {
 
 		// phpcs:ignore -- OK to query DB directly.
 		$wpdb->update( $wpdb->posts, array_merge( $data, $timestamps ), [ 'ID' => $post_id ] );
+
+		do_action( 'ncc_after_post_table_update', 'wp', $post_id, $data );
 	}
 
 	/**


### PR DESCRIPTION
this PR adds 2 new actions to 3 functions (more below). this was a change we made on version we ran on the NASA Flagship site, as we needed to do some data processing once the HTML to Block conversion was done. we felt this would be useful for other folks as well.

#### do_action( 'ncc_after_post_content_saved', $post_id, $blocks_content_patched, $html_content, $blocks_content );

> found in `save_converted_post_content` this passes the original post ID along with the content parts and newly patched content.

#### do_action( 'ncc_after_post_table_update', $table, $post_id, $data );

> found in `update_ncc_posts_table` and `update_posts_table` this passes the original post ID and data array, along with a key indicating which table was updated, currently set to `ncc` or `wp`.

please let me know if there are any specific commenting or documentation I should add as well. thanks!