### PR TITLE
Add a minimum and maximum post ID option 

### DIFF
--- a/assets/src/conversion/index.js
+++ b/assets/src/conversion/index.js
@@ -40,6 +40,8 @@ class Conversion extends Component {
 			totalNumberOfBatches: '...',
 			areThereSuccessfullyConvertedIds: false,
 			areThereUnconvertedIds: false,
+			minIdToProcess: -1,
+			maxIdToProcess: -1,
 		};
 	}
 
@@ -52,6 +54,8 @@ class Conversion extends Component {
 					totalNumberOfBatches,
 					areThereSuccessfullyConvertedIds,
 					areThereUnconvertedIds,
+					minIdToProcess,
+					maxIdToProcess,
 				} = response;
 				this.setState( {
 					isConversionPrepared,
@@ -59,6 +63,8 @@ class Conversion extends Component {
 					totalNumberOfBatches,
 					areThereSuccessfullyConvertedIds,
 					areThereUnconvertedIds,
+					minIdToProcess,
+					maxIdToProcess,
 				} );
 			}
 			return new Promise( ( resolve, reject ) => resolve() );
@@ -96,6 +102,8 @@ class Conversion extends Component {
 			totalNumberOfBatches,
 			areThereSuccessfullyConvertedIds,
 			areThereUnconvertedIds,
+			minIdToProcess,
+			maxIdToProcess,
 		} = this.state;
 		if ( '1' == isConversionPrepared ) {
 			return (
@@ -177,6 +185,12 @@ class Conversion extends Component {
 								value={ totalNumberOfBatches }
 							/>
 						</CardBody>
+						{ ( maxIdToProcess > 0 || minIdToProcess > 0 )&& (
+							<CardBody>
+								{ ( minIdToProcess > 0 ) && ( <p>{ sprintf( __( 'Min post ID to process is set to %d' ), minIdToProcess) } </p> ) }
+								{ ( maxIdToProcess > 0 ) && ( <p>{ sprintf( __( 'Max post ID to process is set to %d' ), maxIdToProcess) } </p> ) }
+							</CardBody>
+						) }
 						{ ( areThereSuccessfullyConvertedIds || areThereUnconvertedIds )&& (
 							<CardBody>
 								{ areThereSuccessfullyConvertedIds && (

--- a/lib/class-conversionprocessor.php
+++ b/lib/class-conversionprocessor.php
@@ -86,6 +86,9 @@ class ConversionProcessor {
 		$post_statuses         = $this->get_conversion_post_statuses();
 		$statuses_placeholders = implode( ',', array_fill( 0, count( $post_statuses ), '%s' ) );
 
+		$min_post_id_to_process = get_option( 'ncc_min_post_id_to_process', 0 );
+		$max_post_id_to_process = get_option( 'ncc_max_post_id_to_process', PHP_INT_MAX );
+
 		// Get unconverted IDs. Exclude posts that begin with block code.
 		// phpcs:disable -- WordPress.DB.PreparedSQLPlaceholders.LikeWildcardsInQuery.
 		$ids = $wpdb->get_col(
@@ -95,10 +98,16 @@ class ConversionProcessor {
 				-- Select desired post types.
 				WHERE post_type IN ( {$types_placeholders} )
 				AND post_status IN ( {$statuses_placeholders} )
+				AND ID BETWEEN %d AND %d
 				-- Filter out post which are already in blocks.
 				AND post_content NOT LIKE '<!-- wp:%'
 				ORDER BY ID DESC ;",
-				array_merge( $post_types, $post_statuses )
+				[
+					...$post_types,
+					...$post_statuses,
+					$min_post_id_to_process,
+					$max_post_id_to_process,
+				]
 			)
 		);
 		// phpcs:enable

--- a/lib/class-convertercontroller.php
+++ b/lib/class-convertercontroller.php
@@ -219,6 +219,8 @@ class ConverterController extends WP_REST_Controller {
 		$total_number_of_batches              = ceil( $unconverted_count / $this->conversion_processor->get_conversion_batch_size() );
 		$are_there_successfully_converted_ids = count( $this->conversion_processor->get_all_converted_ids() ) > 0;
 		$are_there_unconverted_ids            = $unconverted_count > 0;
+		$min_id_to_process                    = get_option( 'ncc_min_post_id_to_process', -1 );
+		$max_id_to_process                    = get_option( 'ncc_max_post_id_to_process', -1 );
 
 		$response = rest_ensure_response(
 			[
@@ -227,6 +229,8 @@ class ConverterController extends WP_REST_Controller {
 				'totalNumberOfBatches'             => $total_number_of_batches,
 				'areThereSuccessfullyConvertedIds' => $are_there_successfully_converted_ids,
 				'areThereUnconvertedIds'           => $are_there_unconverted_ids,
+				'minIdToProcess'                   => $min_id_to_process,
+				'maxIdToProcess'                   => $max_id_to_process,
 			]
 		);
 		return $response;


### PR DESCRIPTION
This is so the processing can be narrowed down

This is very simple for now. There is no UI to set the options, so that would need to be done from CLI, filtering, or in a pinch – the wp-admin/options.php page.

If the values are set, it would look something like this in the UI:
![CleanShot 2024-05-07 at 11 20 22@2x](https://github.com/Automattic/newspack-content-converter/assets/193283/00dd14cb-9cc9-4093-88ed-78bb78e2fb4a)

## How to test
First, just verify that there is nothing new in the UI on `wp-admin/admin.php?page=newspack-content-converter`.
Now set a minimum: 
`wp option update ncc_min_post_id_to_process xx`
and verify that the minimum is shown (and respected).

Do the same with a maximum:
`wp option update ncc_max_post_id_to_process xxx`
and verify that it is shown and respected.

