### PR TITLE
Ignore the .cache dir in making a release

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "dev": "run-p \"dev:*\"",
     "start": "npm run dev",
     "release:build-all": "composer install --no-dev && NODE_ENV=production run-p \"build\"",
-    "release:archive": "mkdir -p assets/release && zip -r assets/release/newspack-content-converter.zip . -x assets/release/\\* bin/\\* tests/\\* node_modules/\\* .git/\\* .github/\\* .gitignore .editorconfig .prettierrc phpcs.xml phpunit.xml.dist .DS_Store",
+    "release:archive": "mkdir -p assets/release && zip -r assets/release/newspack-content-converter.zip . -x assets/release/\\* bin/\\* tests/\\* node_modules/\\* .git/\\* .github/\\* .cache/\\* .gitignore .editorconfig .prettierrc phpcs.xml phpunit.xml.dist .DS_Store",
     "release": "run-p \"clean\" && run-p \"release:build-all\" && run-p \"release:archive\""
   },
   "devDependencies": {


### PR DESCRIPTION
This just adds the `.cache` dir to ignored dirs when creating the .zip.