### PR TITLE
Add support for Gallery Blocks conversion from Gallery Shortcode

### DIFF
--- a/assets/src/utilities/index.js
+++ b/assets/src/utilities/index.js
@@ -80,7 +80,7 @@ export function getPostContentById( id ) {
  */
 export function insertClassicBlockWithContent( html ) {
 	return new Promise( function( resolve, reject ) {
-		const block = parse(html);
+		const block = parse( html );
 
 		dispatch( 'core/block-editor' ).insertBlocks( block );
 

--- a/assets/src/utilities/index.js
+++ b/assets/src/utilities/index.js
@@ -2,8 +2,9 @@
  * WordPress dependencies.
  */
 import apiFetch from '@wordpress/api-fetch';
-import { createBlock, getBlockContent, rawHandler } from '@wordpress/blocks';
-import { dispatch, select } from '@wordpress/data';
+import { createBlock, parse, rawHandler, serialize } from '@wordpress/blocks';
+import { dispatch, select, resolveSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
 
 const NEWSPACK_CONVERTER_API_BASE_URL = '/newspack-content-converter';
 
@@ -79,10 +80,10 @@ export function getPostContentById( id ) {
  */
 export function insertClassicBlockWithContent( html ) {
 	return new Promise( function( resolve, reject ) {
-		const block = createBlock( 'core/freeform' );
-		block.attributes.content = html;
+		const block = parse(html);
+
 		dispatch( 'core/block-editor' ).insertBlocks( block );
-		// --- OR: let block = wp.blocks.createBlock( "core/freeform", { content: 'test' } );
+
 		resolve( html );
 	} );
 }
@@ -94,20 +95,66 @@ export function insertClassicBlockWithContent( html ) {
  * @returns {Promise<any> | Promise}
  */
 export function dispatchConvertClassicToBlocks( html ) {
-	return new Promise( function( resolve, reject ) {
-		select( 'core/block-editor' )
-			.getBlocks()
-			.forEach( function( block, blockIndex ) {
-				if ( block.name === 'core/freeform' ) {
-					// Previously here used now deprecated `dispatch( 'core/editor' ).replaceBlocks()`.
-					wp.data.dispatch( 'core/block-editor' ).replaceBlocks(
-						block.clientId,
-						rawHandler( {
-							HTML: getBlockContent( block ),
-						} )
-					);
-				}
+	return new Promise( async function( resolve, reject ) {
+		const blocks = select( 'core/block-editor' ).getBlocks();
+
+		for (let block of blocks) {
+			if ( block.name !== 'core/freeform' ) {
+				continue;
+			}
+
+			const newBlocks = rawHandler( {
+				HTML: serialize( block ),
 			} );
+
+			for (let newBlock of newBlocks) {
+				if ( newBlock.name !== 'core/gallery' ) {
+					continue;
+				}
+
+				const attachmentIds = newBlock.innerBlocks
+					.filter( ( imageBlock ) => imageBlock.attributes.id !== undefined )
+					.map( ( imageBlock ) => imageBlock.attributes.id );
+
+				// Fetch Image Data from API
+				const attachments = await resolveSelect( coreStore ).getMediaItems( {
+					include: attachmentIds,
+					per_page: -1,
+					orderby: 'include',
+				} );
+
+				for (let galleryImageBlockIndex = 0; galleryImageBlockIndex < newBlock.innerBlocks.length; galleryImageBlockIndex++) {
+					const galleryImageBlock = newBlock.innerBlocks[galleryImageBlockIndex];
+
+					const { sizeSlug, linkTo } = newBlock.attributes;
+					const { id } = galleryImageBlock.attributes;
+
+					const attachment = attachments.find( ( attachment ) => attachment.id === id );
+
+					const imageBlock = createBlock( 'core/image', {
+						url: attachment?.source_url,
+						id: id ? parseInt( id, 10 ) : null,
+						alt: attachment?.alt_text,
+						sizeSlug: sizeSlug,
+						linkDestination: linkTo,
+						caption: attachment?.caption?.raw,
+					} );
+
+					wp.data.dispatch( 'core/block-editor' ).replaceBlocks(
+						galleryImageBlock.clientId,
+						imageBlock
+					);
+
+					newBlock.innerBlocks[ galleryImageBlockIndex ] = imageBlock;
+				}
+			}
+
+			wp.data.dispatch( 'core/block-editor' ).replaceBlocks(
+				block.clientId,
+				newBlocks
+			);
+		}
+
 		resolve( html );
 	} );
 }


### PR DESCRIPTION
**Related Issue:** https://github.com/Automattic/newspack-content-converter/issues/140

Add support for Galleries conversion from a shortcode to a Gallery Block.

The approach that we followed prior to this PR was not converting the Gallery shortcode to proper Gallery Block. Instead there were several different issues.

**1) When there is a [gallery ids="24,25,26"] only in a Post Content**

Imagine the following Post Content:

```
[gallery ids="24,25,26"]
```

The shortcode was converted to a Paragraph Block with the shortcode inside in the following format:

```
<!-- wp:paragraph -->
<p>[gallery ids="24,25,26"]</p>
<!-- /wp:paragraph -->
```

The reason behind that was that the default behaviour in WordPress is to always wrap content in paragraphs.

While debugging this, I've found that when using the following code to parse the Classic Content into a Classic Block (core/freeform) it doesn't get it wrapped in paragraphs:

```
const block = createBlock( 'core/freeform' );
block.attributes.content = html;
```

So, instead of doing this I've followed how Gutenberg does it when hydrating the initial Post Content in the editor and found that they are using the `parse` function in the following way:

```
const block = parse(html);
```

This, wrapped the Gallery shortcode in a paragraph internally and converting the content led to a gallery block with empty images.

**2) When there is a paragraph with a gallery shortcode inside**

**Example content:**

```
<p>[gallery ids="24,25,26"]</p>
```

When converting to Blocks, the output contained a skeleton of a Gallery with the proper number of inner blocks for images, but didn't show any images.

**Example output:**

```
<!-- wp:gallery {"columns":3,"linkTo":"none"} -->
<figure class="wp-block-gallery has-nested-images columns-3 is-cropped"><!-- wp:image {"id":26} -->
<figure class="wp-block-image"><img alt="" class="wp-image-26"/></figure>
<!-- /wp:image -->

<!-- wp:image {"id":25} -->
<figure class="wp-block-image"><img alt="" class="wp-image-25"/></figure>
<!-- /wp:image -->

<!-- wp:image {"id":24} -->
<figure class="wp-block-image"><img alt="" class="wp-image-24"/></figure>
<!-- /wp:image --></figure>
<!-- /wp:gallery -->
```

**Notice that the `<img>` tags don't contain any `src` attribute and thus the image is not displayed!**

---

After some further investigation, I found that Gutenberg does this by default. In order to populate the needed img src attributes, there is an additional step that queries the attachments data from the REST API and uses the response to populate the missing Gallery details.

This approach makes sense since we don't have the Attachment details initially (remember that the Gallery shortcode contains only the IDs of the Attachments).

So, naturally this PR adds the missing resolution of Gallery Images and changes the inner blocks to contain the needed details.

In addition to that, with this PR we are preserving the caption of the images, which currently is broken when using the Gutenberg Convert to Blocks button (PR for the Gutenberg Repo soon to be opened 🤞)

---

Finally, the proper end result of a converted post containing Gallery Shortcode will now be:

```
<!-- wp:gallery {"columns":3,"linkTo":"none"} -->
<figure class="wp-block-gallery has-nested-images columns-3 is-cropped"><!-- wp:image {"id":26,"sizeSlug":"large","linkDestination":"none"} -->
<figure class="wp-block-image size-large"><img src="https://example.com/wp-content/uploads/2024/07/image-1.png" alt="" class="wp-image-26"/><figcaption class="wp-element-caption">Test 1</figcaption></figure>
<!-- /wp:image -->

<!-- wp:image {"id":25,"sizeSlug":"large","linkDestination":"none"} -->
<figure class="wp-block-image size-large"><img src="https://example.com/wp-content/uploads/2024/07/image-2.jpeg" alt="" class="wp-image-25"/><figcaption class="wp-element-caption">Test 2</figcaption></figure>
<!-- /wp:image -->

<!-- wp:image {"id":24,"sizeSlug":"large","linkDestination":"none"} -->
<figure class="wp-block-image size-large"><img src="https://example.com/wp-content/uploads/2024/07/image-3.png" alt="" class="wp-image-24"/><figcaption class="wp-element-caption">Test 3</figcaption></figure>
<!-- /wp:image --></figure>
<!-- /wp:gallery -->
```