### PR TITLE
Gallery Conversion: Strip empty attachment ids (#152)

### DIFF
--- a/assets/src/utilities/index.js
+++ b/assets/src/utilities/index.js
@@ -112,7 +112,7 @@ export function dispatchConvertClassicToBlocks( html ) {
 
 			for ( let galleryBlock of galleryBlocks ) {
 				const attachmentIds = galleryBlock.innerBlocks
-					.filter( ( imageBlock ) => imageBlock.attributes.id !== undefined )
+					.filter( ( imageBlock ) => Number.isInteger( imageBlock.attributes.id ) )
 					.map( ( imageBlock ) => imageBlock.attributes.id );
 
 				// Fetch Image Data from API
@@ -125,24 +125,29 @@ export function dispatchConvertClassicToBlocks( html ) {
 				galleryBlock.innerBlocks.forEach( ( galleryImageBlock, galleryImageBlockIndex ) => {
 					const { sizeSlug, linkTo } = galleryBlock.attributes;
 					const { id } = galleryImageBlock.attributes;
-	
-					const attachment = attachments.find( ( attachment ) => attachment.id === id );
-	
-					const imageBlock = createBlock( 'core/image', {
-						url: attachment?.source_url,
-						id: id ? parseInt( id, 10 ) : null,
-						alt: attachment?.alt_text,
-						sizeSlug: sizeSlug,
-						linkDestination: linkTo,
-						caption: attachment?.caption?.raw,
-					} );
-	
-					wp.data.dispatch( 'core/block-editor' ).replaceBlocks(
-						galleryImageBlock.clientId,
-						imageBlock
-					);
-	
-					galleryBlock.innerBlocks[ galleryImageBlockIndex ] = imageBlock;
+
+					if ( ! id ) {
+						// Image Block has an empty ID and needs to be removed
+						galleryBlock.innerBlocks.splice( galleryImageBlockIndex, 1 );
+					} else {
+						const attachment = attachments.find( ( attachment ) => attachment.id === id );
+
+						const imageBlock = createBlock( 'core/image', {
+							url: attachment?.source_url,
+							id: id ? parseInt( id, 10 ) : null,
+							alt: attachment?.alt_text,
+							sizeSlug: sizeSlug,
+							linkDestination: linkTo,
+							caption: attachment?.caption?.raw,
+						} );
+
+						wp.data.dispatch( 'core/block-editor' ).replaceBlocks(
+							galleryImageBlock.clientId,
+							imageBlock
+						);
+
+						galleryBlock.innerBlocks[ galleryImageBlockIndex ] = imageBlock;
+					}
 				} );
 			}
 


### PR DESCRIPTION
This PR fixes an [issue](https://github.com/Automattic/newspack-content-converter/issues/152) where a Gallery shortcode with empty IDs throws an error for non-integer attachment ID.

### How to test

1. By using Classic Editor, create a post with a Gallery shortcode
2. Select several images from the Media Library
3. Switch to HTML editor and put an empty ID to the attachment IDs shortcode attribute
4. Run NCC

The result should be a Gallery Block with missing Image Block for the empty attachment ID. So, if you had 4 attachment IDs and one empty, you should end up with only 4 Image Blocks in the Gallery Block.

