### PR TITLE
Store revision before post content update (#154)

### DIFF
--- a/lib/class-conversionprocessor.php
+++ b/lib/class-conversionprocessor.php
@@ -356,8 +356,15 @@ class ConversionProcessor {
 			// Back up original post_content as post meta.
 			add_post_meta( $post_id, self::POSTMETA_ORIGINAL_POST_CONTENT, $current_post_content );
 
+			// Store revision before the content has been updated.
+			// No need to store revision after update since the update triggers that.
+			wp_save_post_revision( $post_id );
+
 			// Update post_content.
-			$wpdb->update( $wpdb->posts, [ 'post_content' => $blocks_content_patched ], [ 'ID' => $post_id ] );
+			wp_update_post( [
+				'ID' => $post_id,
+				'post_content' => $blocks_content_patched,
+			] );
 
 			/**
 			 * Fires after post content has been updated.


### PR DESCRIPTION
This PR solves the issues described [here](https://github.com/Automattic/newspack-content-converter/issues/154).

We are changing two things:

**1. Store a revision before the Post is being updated**

We need a snapshot to use the revisions comparison tool against. That's why we store the old post content.

**2. Replace `$wpdb->update` with `wp_update_post`**

The change here is needed since `wp_update_post` triggers other hooks that will make sure a revision is created after update.

@iuravic I saw that you used `$wpdb->update`. Let me know if you have any concerns about this change :)

---

### How to test

1. Create a Post
2. Add some content (e.g. gallery shortcode) through Classic Editor
3. Run NCC
4. Open the Post in Gutenberg. You should see **"Revisions: 2"** in the Post Settings panel on the right side of the screen.
5. If you click the number, you should be redirected to the Revisions Comparison page.
6. From there, you should be able to see the following changes:
    6.a. Empty Content -> Gallery Shortcode
    6.b. Gallery Shortcode -> Gallery Block