### PR TITLE
Remove posts with empty content from conversion

### DIFF
--- a/lib/class-conversionprocessor.php
+++ b/lib/class-conversionprocessor.php
@@ -104,6 +104,7 @@ class ConversionProcessor {
 				AND post_status IN ( {$statuses_placeholders} )
 				AND ID BETWEEN %d AND %d
 				-- Filter out post which are already in blocks.
+				AND post_content != ''
 				AND post_content NOT LIKE '<!-- wp:%'
 				ORDER BY ID DESC ;",
 				[


### PR DESCRIPTION
The idea behind this PR is to remove posts with empty content from the conversion process. Such type of posts won't be altered and just add some noise to the number of "Unconverted Entries" since they always add to the total count.