### PR TITLE
chore(deps): remove @wordpress/base-styles package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "name": "newspack-content-converter",
       "version": "1.2.0",
       "dependencies": {
-        "@wordpress/base-styles": "^3.3.2",
         "@wordpress/components": "^12.0.5",
         "newspack-components": "^3.1.0",
         "npm-run-all": "^4.1.5",
@@ -9781,11 +9780,6 @@
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
       }
-    },
-    "node_modules/@wordpress/base-styles": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-3.6.0.tgz",
-      "integrity": "sha512-6/vXAmc9FSX7Y17UjKgUJoVU++Pv1U1G8uMx7iClRUaLetc7/jj2DD9PTyX/cdJjHr32e3yXuLVT9wfEbo6SEg=="
     },
     "node_modules/@wordpress/blob": {
       "version": "3.53.0",
@@ -57995,11 +57989,6 @@
           }
         }
       }
-    },
-    "@wordpress/base-styles": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-3.6.0.tgz",
-      "integrity": "sha512-6/vXAmc9FSX7Y17UjKgUJoVU++Pv1U1G8uMx7iClRUaLetc7/jj2DD9PTyX/cdJjHr32e3yXuLVT9wfEbo6SEg=="
     },
     "@wordpress/blob": {
       "version": "3.53.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
     "npm": "8"
   },
   "dependencies": {
-    "@wordpress/base-styles": "^3.3.2",
     "@wordpress/components": "^12.0.5",
     "newspack-components": "^3.1.0",
     "npm-run-all": "^4.1.5",


### PR DESCRIPTION
Removes the `@wordpress/base-styles` package as it is not used.