### PR TITLE
chore: pin third-party GitHub Actions to SHAs + enable Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    groups:
+      actions-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      actions-major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+    cooldown:
+      default-days: 7
+      semver-major-days: 14

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -12,7 +12,7 @@ jobs:
       && ! contains( github.event.pull_request.labels.*.name, '[Status] Approved' )
     steps:
       - uses: actions/checkout@v2
-      - uses: ahmadnassri/action-dependabot-auto-merge@v2
+      - uses: ahmadnassri/action-dependabot-auto-merge@45fc124d949b19b6b8bf6645b6c9d55f4f9ac61a # v2.6.6
         with:
           target: minor # includes patch updates.
           github-token: ${{ secrets.DEPENDABOT_TOKEN }}


### PR DESCRIPTION
Two-in-one hardening:

1. Pin third-party GitHub Actions in this repo to commit SHAs (tag preserved as trailing comment).
2. Add Dependabot `github-actions` config (weekly, grouped into `actions-minor-patch` and `actions-major`, with cooldown).

Tracking: DEVPROD-1072.
